### PR TITLE
adding libsodium-dev to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ MAINTAINER Jeff Allen <docker@trestletech.com>
 RUN apt-get update -qq && apt-get install -y \
   git-core \
   libssl-dev \
-  libcurl4-gnutls-dev
+  libcurl4-gnutls-dev \
+  libsodium-dev
 
 ## RUN R -e 'install.packages(c("devtools"))'
 ## RUN R -e 'devtools::install_github("trestletech/plumber")'


### PR DESCRIPTION
Adding libsodium-dev to dev. Reference: [issue 425](https://github.com/trestletech/plumber/issues/425)