### PR TITLE
Fix error handling in serializer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@ plumber 0.5.0
 
 ### Bug fixes
 
+* Fix bug preventing error handling when a serializer fails (@antoine-sachet, [#490](https://github.com/rstudio/plumber/pull/490))
+
 * Fix URL-decoding of query parameters and URL-encoding/decoding of cookies. Both now use `httpuv::decodeURIComponent` instead of `httpuv::decodeURI`. (@antoine-sachet, [#462](https://github.com/trestletech/plumber/pull/462))
 
 * Fix bugs that prevented `do_provision` from deploying to DigitalOcean and updated to the latest `analogsea`.  ([#448](https://github.com/trestletech/plumber/pull/448/files))

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -450,7 +450,7 @@ plumber <- R6Class(
           private$runHooks("preserialize", list(data = hookEnv, req = req, res = res, value = value))
         }
         serializeStep <- function(value, ...) {
-          ser(value, req, res, errorHandler)
+          ser(value, req, res, private$errorHandler)
         }
         postserializeStep <- function(value, ...) {
           private$runHooks("postserialize", list(data = hookEnv, req = req, res = res, value = value))

--- a/tests/testthat/files/serializer-error.R
+++ b/tests/testthat/files/serializer-error.R
@@ -1,0 +1,5 @@
+#* @get /fail
+#* @serializer failingSer
+function() {
+  "Serialization will fail"
+}


### PR DESCRIPTION
The serializer step in plumber was not updated when the errorHandler was put in `private`. This causes the error handling to fail with `object "errorHandler" not found` if the serializer fails.

This was a simply typo fix but I added a test anyway. Fixes #489.

PR task list:
- [X] Update NEWS
- [X] Add tests
- [X] Update documentation with `devtools::document()`
