### PR TITLE
Ensures that mounted routers have a leading slash

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@ plumber 0.5.0
 
 ### Bug fixes
 
+* Fix possible bugs due to mounted routers without leading slashes (@atheriel, [#476](https://github.com/trestletech/plumber/issues/476) [#501](https://github.com/trestletech/plumber/pull/501)).
+
 * Fix bug preventing error handling when a serializer fails (@antoine-sachet, [#490](https://github.com/rstudio/plumber/pull/490))
 
 * Fix URL-decoding of query parameters and URL-encoding/decoding of cookies. Both now use `httpuv::decodeURIComponent` instead of `httpuv::decodeURI`. (@antoine-sachet, [#462](https://github.com/trestletech/plumber/pull/462))

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -322,7 +322,13 @@ plumber <- R6Class(
       httpuv::runServer(host, port, self)
     },
     mount = function(path, router){
-      path <- sub("([^/])$", "\\1/", path)
+      # Ensure that the path has both a leading and trailing slash.
+      if (!startsWith(path, "/")) {
+        path <- paste0("/", path)
+      }
+      if (!endsWith(path, "/")) {
+        path <- paste0(path, "/")
+      }
 
       private$mnts[[path]] <- router
     },

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -150,9 +150,17 @@ test_that("mounts can be read correctly", {
 
   stat <- PlumberStatic$new(".")
   pr$mount("/static", stat)
+  pr$mount("missing-slashes", stat)
+  pr$mount("/both-slashes/", stat)
+  pr$mount("trailing-slash/", stat)
+  pr$mount("/extra-slash//", stat)
 
-  expect_length(pr$routes, 3)
+  expect_length(pr$routes, 7)
   expect_s3_class(pr$mounts[["/static/"]], "plumberstatic")
+  expect_s3_class(pr$mounts[["/missing-slashes/"]], "plumberstatic")
+  expect_s3_class(pr$mounts[["/both-slashes/"]], "plumberstatic")
+  expect_s3_class(pr$mounts[["/trailing-slash/"]], "plumberstatic")
+  expect_s3_class(pr$mounts[["/extra-slash//"]], "plumberstatic")
   expect_s3_class(pr$mounts[["/mysubpath/"]], "plumber")
 })
 


### PR DESCRIPTION
This should fix #476. Since Plumber already ensures that there is a trailing slash, this just does the same for a leading slash as well, rather than issue an error (which was the other suggested solution).

The examples from that thread now work correctly.

PR task list:
- [x] Update NEWS
- [x] Add tests
- [x] Update documentation with `devtools::document()`
