### PR TITLE
Use bytes charset for multipart input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,3 @@
-Encoding: UTF-8
 Package: plumber
 Type: Package
 Title: An API Generator for R
@@ -45,6 +44,7 @@ Remotes:
     rstudio/swagger,
     rstudio/httpuv,
     sckott/analogsea
+Encoding: UTF-8
 Collate:
     'async.R'
     'content-types.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+* Multipart input is not parsed for query strings (#504, @krlmlr).
+
 plumber 0.5.0
 --------------------------------------------------------------------------------
 ## Full changelog

--- a/R/content-types.R
+++ b/R/content-types.R
@@ -56,6 +56,9 @@ getCharacterSet <- function(contentType){
   if (is.null(contentType)) {
     return(default)
   }
+  if(grepl("^multipart/", contentType)) {
+    return("bytes")
+  }
   charsetStart <- attr(
     gregexpr(".*charset=(.*)", contentType, perl = T)[[1]],
     "capture.start"

--- a/R/post-body.R
+++ b/R/post-body.R
@@ -15,7 +15,7 @@ postBodyFilter <- function(req){
 parseBody <- function(body, charset = "UTF-8"){
   # The body in a curl call can also include querystring formatted data
   # Is there data in the request?
-  if (is.null(body) || length(body) == 0 || body == "") {
+  if (is.null(body) || length(body) == 0 || body == "" || charset == "bytes") {
     return(list())
   }
 
@@ -28,7 +28,7 @@ parseBody <- function(body, charset = "UTF-8"){
     ret <- safeFromJSON(body)
   } else {
     # If not handle it as a query string
-      ret <- parseQS(body)
+    ret <- parseQS(body)
   }
   ret
 }

--- a/tests/testthat/test-postbody.R
+++ b/tests/testthat/test-postbody.R
@@ -4,6 +4,12 @@ test_that("JSON is consumed on POST", {
   expect_equal(parseBody('{"a":"1"}'), list(a = "1"))
 })
 
+test_that("bytes are ignored on POST", {
+  body <- "dummy"
+  Encoding(body) <- "bytes"
+  expect_equal(parseBody(body), list())
+})
+
 test_that("Query strings on post are handled correctly", {
   expect_equivalent(parseBody("a="), list()) # It's technically a named list()
   expect_equal(parseBody("a=1&b=&c&d=1"), list(a="1", d="1"))


### PR DESCRIPTION
Closes #75.

My fork of @sellorm's demo at https://github.com/krlmlr/plumber-uploader/tree/f-multipart contains an example of reliably processing multipart data using `mime::parse_multipart()`. This PR adds special treatment for multipart input.


## Pull Request

Before you submit a pull request, please do the following:

* Add an entry to NEWS concisely describing what you changed.

* Add unit tests in the tests/testthat directory.

* Run Build->Check Package in the RStudio IDE, or `devtools::check()`, to make sure your change did not add any messages, warnings, or errors.

Doing these things will make it easier for the plumber development team to evaluate your pull request. Even so, we may still decide to modify your code or even not merge it at all. Factors that may prevent us from merging the pull request include:

* breaking backward compatibility
* adding a feature that we do not consider relevant for plumber
* is hard to understand
* is hard to maintain in the future
* is computationally expensive
* is not intuitive for people to use

We will try to be responsive and provide feedback in case we decide not to merge your pull request.


## Minimal reproducible example

Finally, please include a minimal reprex. The goal of a reprex is to make it as easy as possible for me to recreate your problem so that I can fix it. If you've never heard of a reprex before, start by reading <https://github.com/jennybc/reprex#what-is-a-reprex>, and follow the advice further down the page. Do NOT include session info unless it's explicitly asked for, or you've used `reprex::reprex(..., si = TRUE)` to hide it away.
```r
reprex::reprex({
  library(plumber)
  # insert reprex here

})
```

Delete these instructions once you have read them.

---

Brief description of the original problem and the approach behind your solution.

```r
# insert reprex here
```

PR task list:
- [x] Update NEWS
- [x] Add tests
- [x] Update documentation with `devtools::document()`