### PR TITLE
Swagger server url / OpenAPI server url

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,9 @@ plumber 0.5.0
 
 ### Bug fixes
 
+* Fix bug in setting openapi.json url when HTTP_REFERER is null (@meztez,
+[#421](https://github.com/rstudio/plumber/issues/421))
+
 * Fix possible bugs due to mounted routers without leading slashes (@atheriel, [#476](https://github.com/rstudio/plumber/issues/476) [#501](https://github.com/rstudio/plumber/pull/501)).
 
 * Fix bug preventing error handling when a serializer fails (@antoine-sachet, [#490](https://github.com/rstudio/plumber/pull/490))

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,7 +55,7 @@ plumber 0.5.0
 ### Bug fixes
 
 * Fix bug in setting openapi.json url when HTTP_REFERER is null (@meztez,
-[#421](https://github.com/rstudio/plumber/issues/421))
+[#528](https://github.com/rstudio/plumber/pull/528))
 
 * Fix possible bugs due to mounted routers without leading slashes (@atheriel, [#476](https://github.com/rstudio/plumber/issues/476) [#501](https://github.com/rstudio/plumber/pull/501)).
 

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -265,12 +265,15 @@ plumber <- R6Class(
           # ex: rstudio cloud
           # use the HTTP_REFERER so RSC can find the swagger location to ask
           ## (can't directly ask for 127.0.0.1)
-          referrer_url <- req$HTTP_REFERER
-          referrer_url <- sub("index\\.html$", "", referrer_url)
-          referrer_url <- sub("__swagger__/$", "", referrer_url)
+          if (is.null(req$HTTP_REFERER)) {
+            openapi_server_url <- getOption("plumber.openapi.server.url")
+          } else {
+            openapi_server_url <- sub("index\\.html$|__swagger__/$", "", req$HTTP_REFERER)
+            options("plumber.openapi.server.url" = openapi_server_url)
+          }
           spec$servers <- list(
             list(
-              url = referrer_url,
+              url = openapi_server_url,
               description = "OpenAPI"
             )
           )

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -237,7 +237,7 @@ plumber <- R6Class(
       port <- findPort(port)
 
 
-      message("Running plumber API at ", urlHost(host, port, changeHostLocation = FALSE))
+      message("Running plumber API at ", urlHost(host = host, port = port, changeHostLocation = FALSE))
 
       priorDebug <- getOption("plumber.debug")
       on.exit({ options("plumber.debug" = priorDebug) })
@@ -256,6 +256,17 @@ plumber <- R6Class(
         }
         spec <- self$swaggerFile()
 
+        swaggerUrl <- paste0(getOption(
+            "plumber.apiURL",
+            urlHost(
+              scheme = getOption("plumber.apiScheme", "http"),
+              host   = getOption("plumber.apiHost", host),
+              port   = getOption("plumber.apiPort", port),
+              path   = getOption("plumber.apiPath", ""),
+              changeHostLocation = TRUE
+            )
+        ), "/__swagger__/")
+
         # Create a function that's hardcoded to return the swaggerfile -- regardless of env.
         swagger_fun <- function(req, res, ..., scheme = "deprecated", host = "deprecated", path = "deprecated") {
           if (!missing(scheme) || !missing(host) || !missing(path)) {
@@ -265,15 +276,24 @@ plumber <- R6Class(
           # ex: rstudio cloud
           # use the HTTP_REFERER so RSC can find the swagger location to ask
           ## (can't directly ask for 127.0.0.1)
-          if (is.null(req$HTTP_REFERER)) {
-            openapi_server_url <- getOption("plumber.openapi.server.url")
-          } else {
-            openapi_server_url <- sub("index\\.html$|__swagger__/$", "", req$HTTP_REFERER)
-            options("plumber.openapi.server.url" = openapi_server_url)
+          api_server_url <- swaggerUrl
+          if (isFALSE(getOption("plumber.apiURL", FALSE)) &&
+              isFALSE(getOption("plumber.apiHost", FALSE))) {
+            if (is.null(req$HTTP_REFERER)) {
+              # Prevent leaking host and port if option is not set
+              api_server_url <- character(1)
+            }
+            else {
+              # Use HTTP_REFERER as fallback
+              api_server_url <- req$HTTP_REFERER
+            }
           }
+          api_server_url <- sub("index\\.html$", "", api_server_url)
+          api_server_url <- sub("/__swagger__/$", "", api_server_url)
+
           spec$servers <- list(
             list(
-              url = openapi_server_url,
+              url = api_server_url,
               description = "OpenAPI"
             )
           )
@@ -309,11 +329,7 @@ plumber <- R6Class(
         }
         self$mount("/__swagger__", PlumberStatic$new(swagger::swagger_path()))
 
-        swaggerUrl <- paste0(
-          urlHost(getOption("plumber.apiHost", host), port, changeHostLocation = TRUE),
-          "/__swagger__/"
-        )
-        message("Running Swagger UI  at ", swaggerUrl, sep = "")
+        message("Running Swagger UI at ", swaggerUrl, sep = "")
         # notify swaggerCallback of plumber swagger location
         if (!is.null(swaggerCallback) && is.function(swaggerCallback)) {
           swaggerCallback(swaggerUrl)
@@ -893,7 +909,7 @@ plumber <- R6Class(
 
 
 
-urlHost <- function(host, port, changeHostLocation = FALSE) {
+urlHost <- function(scheme = "http", host, port, path = "", changeHostLocation = FALSE) {
   if (isTRUE(changeHostLocation)) {
     # upgrade swaggerCallback location to be localhost and not catch-all addresses
     # shiny: https://github.com/rstudio/shiny/blob/95173f6/R/server.R#L781-L786
@@ -911,13 +927,7 @@ urlHost <- function(host, port, changeHostLocation = FALSE) {
   if (grepl(":[^/]", host)) {
     host <- paste0("[", host, "]")
   }
-  # if no match against a protocol
-  if (!grepl("://", host)) {
-    # add http protocol
-    # RStudio IDE does NOT like empty protocols like "127.0.0.1:1234/route"
-    # Works if supplying "http://127.0.0.1:1234/route"
-    host <- paste0("http://", host)
-  }
 
-  paste0(host, ":", port)
+  paste0(scheme, "://", host, ":", port, path)
+
 }

--- a/tests/testthat/test-cookies.R
+++ b/tests/testthat/test-cookies.R
@@ -212,7 +212,7 @@ test_that("cookie encyption fails smoothly", {
   # garbage in, no key
   expect_error({
     decodeCookie(garbage, NULL)
-  }, "not a valid JSON string")
+  }, "(not a valid JSON string|embedded nul in string)")
   # garbage in, key
   expect_error({
     decodeCookie(garbage, asCookieKey(randomCookieKey()))

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -473,27 +473,47 @@ test_that("filters and endpoints executed in the appropriate environment", {
 test_that("host is updated properly for printing", {
 
   expect_identical(
-    urlHost("1:1:1", 1234),
+    urlHost(host = "1:1:1", port = 1234),
     "http://[1:1:1]:1234"
   )
   expect_identical(
-    urlHost("::", 1234, FALSE),
+    urlHost(host = "::", port = 1234, changeHostLocation = FALSE),
     "http://[::]:1234"
   )
   expect_identical(
-    urlHost("::", 1234, TRUE),
+    urlHost(host = "::", port = 1234, changeHostLocation = TRUE),
     "http://[::1]:1234"
   )
   expect_identical(
-    urlHost("1.2.3.4", 1234),
+    urlHost(host = "1.2.3.4", port = 1234),
     "http://1.2.3.4:1234"
   )
   expect_identical(
-    urlHost("0.0.0.0", 1234, FALSE),
+    urlHost(host = "0.0.0.0", port = 1234, changeHostLocation = FALSE),
     "http://0.0.0.0:1234"
   )
   expect_identical(
-    urlHost("0.0.0.0", 1234, TRUE),
+    urlHost(host = "0.0.0.0", port = 1234, changeHostLocation = TRUE),
     "http://127.0.0.1:1234"
+  )
+  expect_identical(
+    urlHost(host = "0.0.0.0", port = 1234, changeHostLocation = TRUE),
+    "http://127.0.0.1:1234"
+  )
+  expect_identical(
+    urlHost(host = "0.0.0.0", port = 1234, changeHostLocation = TRUE),
+    "http://127.0.0.1:1234"
+  )
+  expect_identical(
+    urlHost(host = "0.0.0.0", port = 1234, changeHostLocation = TRUE),
+    "http://127.0.0.1:1234"
+  )
+  expect_identical(
+    urlHost(scheme = "http", host = "0.0.0.0", port = 1234, changeHostLocation = TRUE),
+    "http://127.0.0.1:1234"
+  )
+  expect_identical(
+    urlHost(scheme = "http", host = "0.0.0.0", port = 1234, path = "/v1", changeHostLocation = TRUE),
+    "http://127.0.0.1:1234/v1"
   )
 })

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -497,22 +497,6 @@ test_that("host is updated properly for printing", {
     "http://127.0.0.1:1234"
   )
   expect_identical(
-    urlHost(host = "0.0.0.0", port = 1234, changeHostLocation = TRUE),
-    "http://127.0.0.1:1234"
-  )
-  expect_identical(
-    urlHost(host = "0.0.0.0", port = 1234, changeHostLocation = TRUE),
-    "http://127.0.0.1:1234"
-  )
-  expect_identical(
-    urlHost(host = "0.0.0.0", port = 1234, changeHostLocation = TRUE),
-    "http://127.0.0.1:1234"
-  )
-  expect_identical(
-    urlHost(scheme = "http", host = "0.0.0.0", port = 1234, changeHostLocation = TRUE),
-    "http://127.0.0.1:1234"
-  )
-  expect_identical(
     urlHost(scheme = "http", host = "0.0.0.0", port = 1234, path = "/v1", changeHostLocation = TRUE),
     "http://127.0.0.1:1234/v1"
   )


### PR DESCRIPTION
For #421 

Fallback to `req$HTTP_REFERER` when available
OpenAPI server url property is left empty if options are not set to avoid leaking info on `openapi.json` endpoint.

New plumber options to document somewhere.

- `plumber.apiURL` (has precedence over the others)
- `plumber.apiScheme`
- `plumber.apiPort`
- `plumber.apiPath`

Trailing `/` is removed from the OpenAPI server url property per [docs](https://swagger.io/docs/specification/api-host-and-base-path/).

Console message about Swagger UI uses options if they are set.
Modified `urlHost` function and calls to add `scheme` and `path` with default `http` and `character(1)`

Best practice should be to either set `plumber.apiURL`
```r
options("plumber.apiURL" = "https://el.gato/bueno/v1")
```
or use individual options.
```r
options("plumber.apiScheme" = "https")
options("plumber.apiHost" = "el.gato")
options("plumber.apiPort" = 80)
options("plumber.apiPath" = "/bueno/v1")
```
In this case `port` should be provided since it will default to `httuv` serving port when not set.

 PR task list:
 
 * [x]  Update NEWS
 * [x]  Add tests
 * [ ]  Update documentation with `devtools::document()`