### PR TITLE
Update digital ocean R version and base image

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,9 @@ plumber 0.5.0
 
 ### Minor new features and improvements
 
+* R repository modified to `xenial-cran35` and `trusty-cran35` in `install_new_r` scripts (@meztez,
+[#526](https://github.com/rstudio/plumber/issues/526))
+
 * If cookie information is too large (> 4093 bytes), a warning will be displayed. ([#404](https://github.com/rstudio/plumber/pull/404))
 
 * Added new shorthand types for url parameters. (@byzheng, [#388](https://github.com/rstudio/plumber/pull/388))

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,7 +42,7 @@ plumber 0.5.0
 ### Minor new features and improvements
 
 * R repository modified to `xenial-cran35` and `trusty-cran35` in `install_new_r` scripts (@meztez,
-[#526](https://github.com/rstudio/plumber/issues/526))
+[#529](https://github.com/rstudio/plumber/pull/529))
 
 * If cookie information is too large (> 4093 bytes), a warning will be displayed. ([#404](https://github.com/rstudio/plumber/pull/404))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,9 @@ plumber 0.5.0
   non-ASCII characters (@shrektan, [#312](https://github.com/rstudio/plumber/pull/312),
   [#328](https://github.com/rstudio/plumber/pull/328)).
 
+* Docker file R repository modified to `xenial-cran35` and `trusty-cran35` in `install_new_r` scripts (@meztez,
+[#529](https://github.com/rstudio/plumber/pull/529))
+
 ### New features
 
 * Added support for promises in endpoints, filters, and hooks. ([#248](https://github.com/rstudio/plumber/pull/248))
@@ -40,9 +43,6 @@ plumber 0.5.0
 
 
 ### Minor new features and improvements
-
-* R repository modified to `xenial-cran35` and `trusty-cran35` in `install_new_r` scripts (@meztez,
-[#529](https://github.com/rstudio/plumber/pull/529))
 
 * If cookie information is too large (> 4093 bytes), a warning will be displayed. ([#404](https://github.com/rstudio/plumber/pull/404))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,8 +29,7 @@ plumber 0.5.0
   non-ASCII characters (@shrektan, [#312](https://github.com/rstudio/plumber/pull/312),
   [#328](https://github.com/rstudio/plumber/pull/328)).
 
-* Docker file R repository modified to `xenial-cran35` and `trusty-cran35` in `install_new_r` scripts (@meztez,
-[#529](https://github.com/rstudio/plumber/pull/529))
+* R repository modified to `focal-cran40` using Ubuntu 20.04 LTS for digital ocean provisioning (@meztez, #529)
 
 ### New features
 

--- a/R/digital-ocean.R
+++ b/R/digital-ocean.R
@@ -141,7 +141,7 @@ install_nginx <- function(droplet){
 
 install_new_r <- function(droplet){
   analogsea::droplet_ssh(droplet, "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9")
-  analogsea::droplet_ssh(droplet, "echo 'deb https://cran.rstudio.com/bin/linux/ubuntu xenial/' >> /etc/apt/sources.list.d/cran.list")
+  analogsea::droplet_ssh(droplet, "echo 'deb https://cran.rstudio.com/bin/linux/ubuntu xenial-cran35/' >> /etc/apt/sources.list.d/cran.list")
   # TODO: use the analogsea version once https://github.com/sckott/analogsea/issues/139 is resolved
   #analogsea::debian_apt_get_update(droplet)
   analogsea::droplet_ssh(droplet, "sudo apt-get update -qq")

--- a/R/digital-ocean.R
+++ b/R/digital-ocean.R
@@ -19,7 +19,7 @@ checkAnalogSea <- function(){
 #' @param unstable If `FALSE`, will install plumber from CRAN. If `TRUE`, will install the unstable version of plumber from GitHub.
 #' @param example If `TRUE`, will deploy an example API named `hello` to the server on port 8000.
 #' @param ... Arguments passed into the [analogsea::droplet_create()] function.
-#' @details Provisions a Ubuntu 16.04-x64 droplet with the following customizations:
+#' @details Provisions a Ubuntu 20.04-x64 droplet with the following customizations:
 #'  - A recent version of R installed
 #'  - plumber installed globally in the system library
 #'  - An example plumber API deployed at `/var/plumber`
@@ -44,7 +44,7 @@ do_provision <- function(droplet, unstable=FALSE, example=TRUE, ...){
 
     createArgs <- list(...)
     createArgs$tags <- c(createArgs$tags, "plumber")
-    createArgs$image <- "ubuntu-16-04-x64"
+    createArgs$image <- "ubuntu-20-04-x64"
 
     droplet <- do.call(analogsea::droplet_create, createArgs)
 
@@ -141,7 +141,7 @@ install_nginx <- function(droplet){
 
 install_new_r <- function(droplet){
   analogsea::droplet_ssh(droplet, "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9")
-  analogsea::droplet_ssh(droplet, "echo 'deb https://cran.rstudio.com/bin/linux/ubuntu xenial-cran35/' >> /etc/apt/sources.list.d/cran.list")
+  analogsea::droplet_ssh(droplet, "echo 'deb https://cran.rstudio.com/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list.d/cran.list")
   # TODO: use the analogsea version once https://github.com/sckott/analogsea/issues/139 is resolved
   #analogsea::debian_apt_get_update(droplet)
   analogsea::droplet_ssh(droplet, "sudo apt-get update -qq")

--- a/inst/hosted/analogsea-provision.R
+++ b/inst/hosted/analogsea-provision.R
@@ -26,7 +26,7 @@ install_docker <- function(droplet){
 
 install_new_r <- function(droplet){
   droplet %>%
-    droplet_ssh(c("echo 'deb https://cran.rstudio.com/bin/linux/ubuntu trusty/' >> /etc/apt/sources.list",
+    droplet_ssh(c("echo 'deb https://cran.rstudio.com/bin/linux/ubuntu trusty-cran35/' >> /etc/apt/sources.list",
                   "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9")) %>%
     debian_apt_get_update() %>%
     debian_install_r()

--- a/inst/hosted/analogsea-provision.R
+++ b/inst/hosted/analogsea-provision.R
@@ -15,8 +15,9 @@ install <- function(droplet){
 
 install_docker <- function(droplet){
   droplet %>%
+    # Deprecated (Shutting down dockerproject.org APT and YUM repos 2020-03-31)
     droplet_ssh(c("sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D",
-                  "echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list")) %>%
+                  "echo 'deb https://apt.dockerproject.org/repo ubuntu-focal main' > /etc/apt/sources.list.d/docker.list")) %>%
     debian_apt_get_update() %>%
     droplet_ssh("sudo apt-get install linux-image-extra-$(uname -r)") %>%
     debian_apt_get_install("docker-engine") %>%
@@ -26,7 +27,7 @@ install_docker <- function(droplet){
 
 install_new_r <- function(droplet){
   droplet %>%
-    droplet_ssh(c("echo 'deb https://cran.rstudio.com/bin/linux/ubuntu trusty-cran35/' >> /etc/apt/sources.list",
+    droplet_ssh(c("echo 'deb https://cran.rstudio.com/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list",
                   "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9")) %>%
     debian_apt_get_update() %>%
     debian_install_r()

--- a/tests/testthat/test-cookies.R
+++ b/tests/testthat/test-cookies.R
@@ -212,7 +212,7 @@ test_that("cookie encyption fails smoothly", {
   # garbage in, no key
   expect_error({
     decodeCookie(garbage, NULL)
-  }, "not a valid JSON string")
+  }, "(not a valid JSON string|embedded nul in string)")
   # garbage in, key
   expect_error({
     decodeCookie(garbage, asCookieKey(randomCookieKey()))


### PR DESCRIPTION
For #526 

R repository modified to `xenial-cran35` and `trusty-cran35` in `install_new_r` scripts.

 PR task list:
 
 * [x]  Update NEWS
 * [ ]  Add tests
 * [ ]  Update documentation with `devtools::document()`