### PR TITLE
fix cookie test

### DIFF
--- a/R/response.R
+++ b/R/response.R
@@ -59,7 +59,15 @@ removeCookieStr <- function(name, path, http = FALSE, secure = FALSE) {
 }
 
 #' @noRd
-cookieToStr <- function(name, value, path, expiration=FALSE, http=FALSE, secure=FALSE){
+cookieToStr <- function(
+  name,
+  value,
+  path,
+  expiration = FALSE,
+  http = FALSE,
+  secure = FALSE,
+  now = Sys.time() # used for testing. Should not be used in regular code.
+){
   val <- httpuv::encodeURIComponent(as.character(value))
   str <- paste0(name, "=", val, "; ")
 
@@ -78,14 +86,13 @@ cookieToStr <- function(name, value, path, expiration=FALSE, http=FALSE, secure=
   if (!missing(expiration)){
     if (is.numeric(expiration)){
       # Number of seconds in the future
-      now <- Sys.time()
       expy <- now + expiration
       expyStr <- format(expy, format="%a, %e %b %Y %T", tz="GMT", usetz=TRUE)
 
       str <- paste0(str, "Expires= ", expyStr, "; ")
       str <- paste0(str, "Max-Age= ", expiration, "; ")
     } else if (inherits(expiration, "POSIXt")){
-      seconds <- difftime(expiration, Sys.time(), units="secs")
+      seconds <- difftime(expiration, now, units="secs")
       # TODO: DRY
       expyStr <- format(expiration, format="%a, %e %b %Y %T", tz="GMT", usetz=TRUE)
       str <- paste0(str, "Expires= ", expyStr, "; ")

--- a/tests/testthat/test-cookies.R
+++ b/tests/testthat/test-cookies.R
@@ -46,42 +46,38 @@ test_that("missing cookie values are empty string", {
 test_that("cookies can convert to string", {
   testthat::skip_on_cran()
 
-  # timing issues with cookieToStr(expiration = expires).
-  # Win R4.0 equals `expiresSec`; Win Rdevel equals `expiresSec-1`
-  testthat::skip_on_os("windows")
-
   expect_equal(cookieToStr("abc", 123), "abc=123")
   expect_equal(cookieToStr("complex", "string with spaces"), "complex=string%20with%20spaces")
   expect_equal(cookieToStr("complex2", "forbidden:,%/"), "complex2=forbidden%3A%2C%25%2F")
   expect_equal(cookieToStr("abc", 123, path="/somepath"), "abc=123; Path=/somepath")
   expect_equal(cookieToStr("abc", 123, http=TRUE, secure=TRUE), "abc=123; HttpOnly; Secure")
 
+  now <- force(Sys.time())
+  cookieToStr_ <- function(expiration, ...) {
+    cookieToStr("abc", 123, expiration = expiration, ..., now = now)
+  }
+  cookie_match <- function(expirationStr, expiresSec) {
+    # difftime is exclusive, so the Max-Age may be off by one on positive time diffs.
+    #   Using a regex from 0 to 9 incase a slow machine is encountered
+    # match from 0 to 9 seconds
+    paste0("abc=123; Expires= ", expirationStr, "; Max-Age= ", expiresSec)
+  }
+  expect_cookie <- function(expiresSec) {
+    expires <- now + expiresSec
+    expyStr <- format(expires, format="%a, %e %b %Y %T", tz="GMT", usetz=TRUE)
+
+    # When given as a number of seconds
+    expect_equal(cookieToStr_(expiresSec), cookie_match(expyStr, expiresSec), label = "Raw seconds expiration cookie")
+
+    # When given as a POSIXct
+    expect_equal(cookieToStr_(expires), cookie_match(expyStr, expiresSec), label = "POSIXct expiration cookie")
+  }
+
   # Test date in the future
-  expiresSec <- 10
-  expires <- Sys.time() + expiresSec
-  expyStr <- format(expires, format="%a, %e %b %Y %T", tz="GMT", usetz=TRUE)
-  # TODO: this test is vulnerable to Sys.time() crossing over a second boundary in between the
-  # line above and below.
-  # When given as a number of seconds
-  expect_equal(cookieToStr("abc", 123, expiration=expiresSec),
-               paste0("abc=123; Expires= ", expyStr, "; Max-Age= ", expiresSec))
-  # When given as a POSIXct
-  # difftime is exclusive, so the Max-Age may be off by one on positive time diffs.
-  expect_equal(cookieToStr("abc", 123, expiration=expires),
-               paste0("abc=123; Expires= ", expyStr, "; Max-Age= ", expiresSec-1))
+  expect_cookie(9)
 
   # Works with a negative number of seconds
-  expiresSec <- -10
-  expires <- Sys.time() + expiresSec
-  expyStr <- format(expires, format="%a, %e %b %Y %T", tz="GMT", usetz=TRUE)
-  # TODO: this test is vulnerable to Sys.time() crossing over a second boundary in between the
-  # line above and below.
-  # When given as a number of seconds
-  expect_equal(cookieToStr("abc", 123, expiration=expiresSec),
-               paste0("abc=123; Expires= ", expyStr, "; Max-Age= ", expiresSec))
-  # When given as a POSIXct
-  expect_equal(cookieToStr("abc", 123, expiration=expires),
-               paste0("abc=123; Expires= ", expyStr, "; Max-Age= ", expiresSec))
+  expect_cookie(-8)
 })
 
 test_that("remove cookie string works", {


### PR DESCRIPTION
Fixes https://github.com/rstudio/plumber/issues/544

* Adds a `now` parameter.  (Should only be used for testing).