### PR TITLE
Clean up print method

### DIFF
--- a/R/plumber-static.R
+++ b/R/plumber-static.R
@@ -90,7 +90,7 @@ PlumberStatic <- R6Class(
       if (!topLevel){
         cat("\u2502 ")
       }
-      cat(crayon::silver("# Plumber static router serving from directory:", private$dir, "\n"))
+      cat(crayon::silver("# Plumber static router serving from directory: ", private$dir, "\n", sep = ""))
     }
   ), private=list(
     dir = NULL

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -524,8 +524,6 @@ plumber <- R6Class(
         cat(prefix, "\u251c\u2500\u2500", crayon::green("[", f$name, "]", sep=""), "\n", sep="") # "+--"
       }
 
-      paths <- self$routes
-
       printEndpoints <- function(prefix, name, nodes, isLast){
         if (is.list(nodes)){
           verbs <- paste(sapply(nodes, function(n){ n$verbs }), collapse=", ")
@@ -568,8 +566,10 @@ plumber <- R6Class(
               names(node) == ""
             }
 
-          # print all endpoints in a single line with verbs attached together
+          # mounted routers at root location will also have a missing name.
+          # only look for endpoints
           are_endpoints <- has_no_name & vapply(node, inherits, logical(1), "PlumberEndpoint")
+          # print all endpoints in a single line with verbs attached together
           if (any(are_endpoints)) {
             printEndpoints(prefix, name, node[are_endpoints], isLast)
           }
@@ -590,7 +590,7 @@ plumber <- R6Class(
           cat("??")
         }
       }
-      printNode(paths, "", prefix, TRUE)
+      printNode(self$routes, "", prefix, TRUE)
 
       invisible(self)
     },

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -35,7 +35,7 @@ test_that("all options used are `options_plumber()` parameters", {
   options_used <- unique(sort(gsub("getOption|\\(|\"|,|'|\\)", "", matches)))
   plumber_options_used <- grep("^plumber", options_used, value = TRUE)
   ### code to match formals
-  options_plumber_formals <- paste0("plumber.", sort(names(formals(optionsPlumber))))
+  options_plumber_formals <- paste0("plumber.", sort(names(formals(options_plumber))))
 
   expect_equal(
     plumber_options_used,

--- a/tests/testthat/test-parse-block.R
+++ b/tests/testthat/test-parse-block.R
@@ -13,9 +13,9 @@ test_that("plumbBlock works", {
     "#' @filter test",
     "#' @serializer json")
   b <- plumbBlock(length(lines), lines)
-  expect_length(b$path, 2)
-  expect_equal(b$path[[1]], list(verb="POST", path="/"))
-  expect_equal(b$path[[2]], list(verb="GET", path="/"))
+  expect_length(b$paths, 2)
+  expect_equal(b$paths[[1]], list(verb="POST", path="/"))
+  expect_equal(b$paths[[2]], list(verb="GET", path="/"))
   expect_equal(b$filter, "test")
 
   # due to covr changing some code, the return answer is very strange

--- a/tests/testthat/test-plumber-print.R
+++ b/tests/testthat/test-plumber-print.R
@@ -1,0 +1,88 @@
+test_that("prints correctly", {
+  testthat::skip_on_cran()
+  testthat::skip_on_os("windows") # has issues comparing text values
+
+
+  pr <- plumber$new()
+  pr$handle("GET", "/nested/path/here", function(){})
+  pr$handle("POST", "/nested/path/here", function(){})
+
+  pr2 <- plumber$new()
+  pr2$handle("POST", "/something", function(){})
+  pr2$handle("GET", "/", function(){})
+  pr$mount("/mysubpath", pr2)
+
+  stat <- PlumberStatic$new(".")
+  pr$mount("/static", stat)
+
+  # base_pr <- plumber$new()
+  # base_pr$mount("/", pr)
+
+  printed <- capture.output(print(pr))
+
+  expected_output <- c(
+    "# Plumber router with 2 endpoints, 4 filters, and 2 sub-routers.",
+    "# Call run() on this object to start the API.",
+    "├──[queryString]",
+    "├──[postBody]",
+    "├──[cookieParser]",
+    "├──[sharedSecret]",
+    "├──/nested",
+    "│  ├──/path",
+    "│  │  └──/here (GET, POST)",
+    "├──/mysubpath",
+    "│  │ # Plumber router with 2 endpoints, 4 filters, and 0 sub-routers.",
+    "│  ├──[queryString]",
+    "│  ├──[postBody]",
+    "│  ├──[cookieParser]",
+    "│  ├──[sharedSecret]",
+    "│  ├──/ (GET)",
+    "│  └──/something (POST)",
+    "├──/static",
+    "│  │ # Plumber static router serving from directory: ."
+  )
+
+  expect_equal(printed, expected_output)
+})
+
+test_that("prints correctly", {
+  testthat::skip_on_cran()
+  testthat::skip_on_os("windows") # has issues comparing text values
+
+  pr <- plumber$new()
+  sub <- plumber$new()
+  sub$handle("GET", "/", force)
+  sub$handle("POST", "/something", force)
+  sub$handle("GET", "/nested/path", force)
+  sub$handle("POST", "/", force)
+  sub$handle("POST", "/nested/path", force)
+
+  pr$mount("/", sub)
+
+  printed <- capture.output(print(pr))
+
+  expected_output <- c(
+    "# Plumber router with 0 endpoints, 4 filters, and 1 sub-router.",
+    "# Call run() on this object to start the API.",
+    "├──[queryString]",
+    "├──[postBody]",
+    "├──[cookieParser]",
+    "├──[sharedSecret]",
+    "├──/",
+    "│  │ # Plumber router with 5 endpoints, 4 filters, and 0 sub-routers.",
+    "│  ├──[queryString]",
+    "│  ├──[postBody]",
+    "│  ├──[cookieParser]",
+    "│  ├──[sharedSecret]",
+    "│  ├──/ (GET, POST)",
+    "│  ├──/something (POST)",
+    "│  ├──/nested",
+    "│  │  └──/path (GET, POST)"
+  )
+
+  expect_equal(printed, expected_output)
+  # for (i in 1:length(regexps)){
+  #   expect_match(printed[i], regexps[i], info=paste0("on line ", i), fixed = TRUE)
+  # }
+
+})

--- a/tests/testthat/test-plumber-print.R
+++ b/tests/testthat/test-plumber-print.R
@@ -78,8 +78,4 @@ test_that("prints correctly", {
   )
 
   expect_equal(printed, expected_output)
-  # for (i in 1:length(regexps)){
-  #   expect_match(printed[i], regexps[i], info=paste0("on line ", i), fixed = TRUE)
-  # }
-
 })

--- a/tests/testthat/test-plumber-print.R
+++ b/tests/testthat/test-plumber-print.R
@@ -15,9 +15,6 @@ test_that("prints correctly", {
   stat <- PlumberStatic$new(".")
   pr$mount("/static", stat)
 
-  # base_pr <- plumber$new()
-  # base_pr$mount("/", pr)
-
   printed <- capture.output(print(pr))
 
   expected_output <- c(

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -173,51 +173,7 @@ test_that("mounts can be read correctly", {
   expect_s3_class(pr$mounts[["/mysubpath/"]], "plumber")
 })
 
-test_that("prints correctly", {
-  testthat::skip_on_cran()
-  testthat::skip_on_os("windows") # has issues comparing text values
 
-  pr <- plumber$new()
-  pr$handle("GET", "/nested/path/here", function(){})
-  pr$handle("POST", "/nested/path/here", function(){})
-
-  pr2 <- plumber$new()
-  pr2$handle("POST", "/something", function(){})
-  pr2$handle("GET", "/", function(){})
-  pr$mount("/mysubpath", pr2)
-
-  stat <- PlumberStatic$new(".")
-  pr$mount("/static", stat)
-
-  printed <- capture.output(print(pr))
-
-  regexps <- c(
-    "Plumber router with 2 endpoints, 4 filters, and 2 sub-routers",
-    "Call run() on this object",
-    "├──[queryString]",
-    "├──[postBody]",
-    "├──[cookieParser]",
-    "├──[sharedSecret]",
-    "├──/nested",
-    "│  ├──/path",
-    "│  │  └──/here (GET, POST)",
-    "├──/mysubpath",
-    "│  │ # Plumber router with 2 endpoints, 4 filters, and 0 sub-routers.",
-    "│  ├──[queryString]",
-    "│  ├──[postBody]",
-    "│  ├──[cookieParser]",
-    "│  ├──[sharedSecret]",
-    "│  ├──/something (POST)",
-    "│  └──/ (GET)",
-    "├──/static",
-    "│  │ # Plumber static router serving from directory: ."
-  )
-
-  for (i in 1:length(regexps)){
-    expect_match(printed[i], regexps[i], info=paste0("on line ", i), fixed = TRUE)
-  }
-
-})
 
 test_that("mounts work", {
   pr <- plumber$new()

--- a/tests/testthat/test-serializer-csv.R
+++ b/tests/testthat/test-serializer-csv.R
@@ -31,6 +31,6 @@ test_that("Errors call error handler", {
   }
 
   expect_equal(errors, 0)
-  serializer_csv()(parse(text="hi"), data.frame(), PlumberResponse$new("csv"), err = errHandler)
+  serializer_csv()(parse(text="hi"), data.frame(), PlumberResponse$new("csv"), errorHandler = errHandler)
   expect_equal(errors, 1)
 })

--- a/tests/testthat/test-serializer-html.R
+++ b/tests/testthat/test-serializer-html.R
@@ -15,6 +15,6 @@ test_that("Errors call error handler", {
   }
 
   expect_equal(errors, 0)
-  serializer_html()(parse(stop("I crash")), list(), PlumberResponse$new("json"), err = errHandler)
+  serializer_html()(parse(stop("I crash")), list(), PlumberResponse$new("json"), errorHandler = errHandler)
   expect_equal(errors, 1)
 })

--- a/tests/testthat/test-serializer-htmlwidgets.R
+++ b/tests/testthat/test-serializer-htmlwidgets.R
@@ -3,7 +3,7 @@ context("htmlwidgets serializer")
 # Render a simple HTML widget using the visNetwork package
 renderWidget <- function(){
   skip_if_not_installed("visNetwork")
-  
+
   nodes <- data.frame(id = 1:6, title = paste("node", 1:6),
                       shape = c("dot", "square"),
                       size = 10:15, color = c("blue", "red"))
@@ -33,7 +33,7 @@ test_that("Errors call error handler", {
 
   expect_equal(errors, 0)
   suppressWarnings(
-    serializer_htmlwidget()(parse(text="hi"), list(), PlumberResponse$new("htmlwidget"), err = errHandler)
+    serializer_htmlwidget()(parse(text="hi"), list(), PlumberResponse$new("htmlwidget"), errorHandler = errHandler)
   )
   expect_equal(errors, 1)
 })

--- a/tests/testthat/test-serializer-json.R
+++ b/tests/testthat/test-serializer-json.R
@@ -27,7 +27,7 @@ test_that("Errors call error handler", {
   }
 
   expect_equal(errors, 0)
-  serializer_json()(parse(text="hi"), list(), PlumberResponse$new("json"), err = errHandler)
+  serializer_json()(parse(text="hi"), list(), PlumberResponse$new("json"), errorHandler = errHandler)
   expect_equal(errors, 1)
 })
 
@@ -61,6 +61,6 @@ test_that("Unboxed JSON errors call error handler", {
   }
 
   expect_equal(errors, 0)
-  serializer_unboxed_json()(parse(text="hi"), list(), PlumberResponse$new("json"), err = errHandler)
+  serializer_unboxed_json()(parse(text="hi"), list(), PlumberResponse$new("json"), errorHandler = errHandler)
   expect_equal(errors, 1)
 })

--- a/tests/testthat/test-serializer-yaml.R
+++ b/tests/testthat/test-serializer-yaml.R
@@ -31,6 +31,6 @@ test_that("Errors call error handler", {
   }
 
   expect_equal(errors, 0)
-  serializer_yaml()(parse(text="hi"), list(), PlumberResponse$new("yaml"), err = errHandler)
+  serializer_yaml()(parse(text="hi"), list(), PlumberResponse$new("yaml"), errorHandler = errHandler)
   expect_equal(errors, 1)
 })

--- a/tests/testthat/test-serializer.R
+++ b/tests/testthat/test-serializer.R
@@ -126,7 +126,7 @@ test_that("nullSerializer errors call error handler", {
   }
 
   expect_equal(errors, 0)
-  nullSerializer()(parse(stop("I crash")), list(), PlumberResponse$new("json"), err = errHandler)
+  nullSerializer()(parse(stop("I crash")), list(), PlumberResponse$new("json"), errorHandler = errHandler)
   expect_equal(errors, 1)
 })
 


### PR DESCRIPTION
Fixes #564 

Also removes bad partial arg matching warnings.

PR task list:
- [NA] Update NEWS
- [x] Add tests
- [NA] Update documentation with `devtools::document()`
