### PR TITLE
Replace plus sign with space character when parsing a query string

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -94,6 +94,8 @@ plumber 1.0.0
 
 ### Bug fixes
 
+* Handle plus signs in URI as space characters instead of actual plus signs (@meztez, #618)
+
 * Modified images serialization to use content-type serializer. Fixes issue with images pre/postserialize hooks (@meztez, #518).
 
 * Fix possible bugs due to mounted routers without leading slashes (@atheriel, #476 #501).

--- a/R/parse-query.R
+++ b/R/parse-query.R
@@ -21,6 +21,7 @@ parseQS <- function(qs){
   # (Combining keys are also not handled by `parse_query`)
 
   qs <- stri_replace_first_regex(qs, "^[?]", "")
+  qs <- chartr("+", " ", qs)
 
   args <- stri_split_fixed(qs, "&", omit_empty = TRUE)[[1L]]
   kv <- lapply(args, function(x) {

--- a/tests/testthat/test-querystring.R
+++ b/tests/testthat/test-querystring.R
@@ -7,7 +7,7 @@ test_that("query strings are properly parsed", {
 })
 
 test_that("special characters in query strings are handled properly", {
-  expect_equal(parseQS("?a=1+.#"), list(a="1+.#"))
+  expect_equal(parseQS("?a=1+.#"), list(a="1 .#"))
   expect_equal(parseQS("?a=a%20b"), list(a="a b"))
   expect_equal(parseQS('?a=%2C%2B%2F%3F%25%26'), list(a=",+/?%&"))
 })

--- a/tests/testthat/test-querystring.R
+++ b/tests/testthat/test-querystring.R
@@ -6,6 +6,11 @@ test_that("query strings are properly parsed", {
   expect_equal(parseQS("a=1&b=2&c=url%20encoded"), list(a="1", b="2", c="url encoded"))
 })
 
+test_that("path parameters do not convert + to space", {
+  r <- plumber$new(test_path("files/path-params.R"))
+  expect_equal(r$route(make_req("GET", "/car/a+b"), PlumberResponse$new()), "a+b")
+})
+
 test_that("special characters in query strings are handled properly", {
   expect_equal(parseQS("?a=1+.#"), list(a="1 .#"))
   expect_equal(parseQS("?a=a%20b"), list(a="a b"))


### PR DESCRIPTION
```r
plumber:::parseQS("?a=2&a=3&c=&&d=et+te")
```

Fixes #617 

PR task list:
- [x] Update NEWS
- [x] Add tests
- [ ] Update documentation with `devtools::document()`
