### PR TITLE
`register_ui()` should accept arguments, not a list

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,4 @@
 ^logo$
 ^vignettes$
 ^man-roxygen
+rsconnect

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ yarn.lock
 node_modules
 inst/doc
 docs
+rsconnect

--- a/R/ui.R
+++ b/R/ui.R
@@ -128,17 +128,50 @@ unmount_openapi <- function(pr) {
 }
 
 #' Add UI for plumber to use
-#' @param ui A list of that plumber can use to mount
-#' a UI.
-#' @details [register_ui()] is used by other packages like `swagger`.
+#'
+#' [register_ui()] is used by other packages like `swagger`.
 #' When you load these packages, it calls [register_ui()] to provide a user
 #' interface that can interpret your plumber OpenAPI Specifications.
 #'
 #' @param name Name of the UI
 #' @param index A function that returns the HTML content of the landing page of the UI.
+#'   Parameters (besides `req` and `res`) will be supplied as if it is a regular `GET` route.
+#'   Default parameter values may be used when setting the ui.
+#'   Be sure to see the example below.
 #' @param static A function that returns the path to the static assets (images, javascript, css, fonts) the UI will use.
 #'
 #' @export
+#' @examples
+#' \dontrun{
+#' # Example from the `swagger` R package
+#' register_ui(
+#'   name = "swagger",
+#'   index = function(version = "3", ...) {
+#'     swagger::swagger_spec(
+#'       api_path = paste0(
+#'         "window.location.origin + ",
+#'         "window.location.pathname.replace(",
+#'           "/\\(__swagger__\\\\/|__swagger__\\\\/index.html\\)$/, \"\"",
+#'         ") + ",
+#'         "\"openapi.json\""
+#'       ),
+#'       version = version
+#'     )
+#'   },
+#'   static = function(version = "3", ...) {
+#'     swagger::swagger_path(version)
+#'   }
+#' )
+#'
+#' # When setting the UI, `index` and `static` function arguments can be supplied
+#' # * via `pr_set_ui()`
+#' # * or through URL query string variables
+#' pr() %>%
+#'   # Set default argument `version = 3` for the swagger `index` and `static` functions
+#'   pr_set_ui("swagger", version = 3) %>%
+#'   pr_get("/plus/<a:int>/<b:int>", function(a, b) { a + b }) %>%
+#'   pr_run()
+#' }
 #' @rdname register_ui
 register_ui <- function(name, index, static = NULL) {
 

--- a/R/ui.R
+++ b/R/ui.R
@@ -134,23 +134,20 @@ unmount_openapi <- function(pr) {
 #' When you load these packages, it calls [register_ui()] to provide a user
 #' interface that can interpret your plumber OpenAPI Specifications.
 #'
-#' `ui` list expects the following values
-#' \describe{
-#' \item{name}{Name of the UI.}
-#' \item{index}{A function that returns the HTML content of the landing page of the UI.}
-#' \item{static}{A function that returns the path to the static assets (images, javascript, css, fonts) the UI will use.}
-#' }
+#' @param name Name of the UI
+#' @param index A function that returns the HTML content of the landing page of the UI.
+#' @param static A function that returns the path to the static assets (images, javascript, css, fonts) the UI will use.
+#'
 #' @export
 #' @rdname register_ui
-register_ui <- function(ui) {
+register_ui <- function(name, index, static) {
 
-  stopifnot(is.list(ui))
-  stopifnot(is.character(ui$name) && length(ui$name) == 1L)
-  stopifnot(grepl("^[a-zA-Z0-9_]+$", ui$name))
-  stopifnot(is.function(ui$static))
-  stopifnot(is.function(ui$index))
+  stopifnot(is.character(name) && length(name) == 1L)
+  stopifnot(grepl("^[a-zA-Z0-9_]+$", name))
+  stopifnot(is.function(index))
+  if (!is.null(static)) stopifnot(is.function(static))
 
-  ui_root <- paste0("/__", ui$name, "__/")
+  ui_root <- paste0("/__", name, "__/")
   ui_paths <- c("/index.html", "/")
 
   mount_ui_func <- function(pr, api_url, ...) {
@@ -163,14 +160,16 @@ register_ui <- function(ui) {
       args <- utils::modifyList(args_index, list(...))
       # Remove default arguments req and res
       args <- args[!(names(args) %in% c("req", "res"))]
-      do.call(ui$index, args)
+      do.call(index, args)
     }
 
     ui_router <- plumber$new()
     for (path in ui_paths) {
       ui_router$handle("GET", path, ui_index, serializer = serializer_html())
     }
-    ui_router$mount("/", PlumberStatic$new(ui$static(...)))
+    if (!is.null(static)) {
+      ui_router$mount("/", PlumberStatic$new(static(...)))
+    }
 
     if (!is.null(pr$mounts[[ui_root]])) {
       message("Overwritting existing `", ui_root, "` mount")
@@ -187,10 +186,13 @@ register_ui <- function(ui) {
     invisible()
   }
 
-  .globals$UIs[[ui$name]]$mount <- mount_ui_func
-  .globals$UIs[[ui$name]]$unmount <- unmount_ui_func
+  if (is.null(.globals$UIs[[name]])) {
+    .globals$UIs[[name]] <- list()
+  }
+  .globals$UIs[[name]]$mount <- mount_ui_func
+  .globals$UIs[[name]]$unmount <- unmount_ui_func
 
-  invisible()
+  invisible(name)
 }
 #' @export
 #' @rdname register_ui
@@ -200,7 +202,6 @@ registered_uis <- function() {
 
 # TODO: Remove once UI load code moved to respective UI package
 swagger_ui <- list(
-  package = "swagger",
   name = "swagger",
   index = function(version = "3", ...) {
     swagger::swagger_spec(
@@ -215,5 +216,5 @@ swagger_ui <- list(
 
 #' @noRd
 register_uis_onLoad <- function() {
-  register_ui(swagger_ui)
+  register_ui(swagger_ui$name, swagger_ui$index, swagger_ui$static)
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -140,7 +140,7 @@ unmount_openapi <- function(pr) {
 #'
 #' @export
 #' @rdname register_ui
-register_ui <- function(name, index, static) {
+register_ui <- function(name, index, static = NULL) {
 
   stopifnot(is.character(name) && length(name) == 1L)
   stopifnot(grepl("^[a-zA-Z0-9_]+$", name))

--- a/man/register_ui.Rd
+++ b/man/register_ui.Rd
@@ -5,25 +5,54 @@
 \alias{registered_uis}
 \title{Add UI for plumber to use}
 \usage{
-register_ui(name, index, static)
+register_ui(name, index, static = NULL)
 
 registered_uis()
 }
 \arguments{
 \item{name}{Name of the UI}
 
-\item{index}{A function that returns the HTML content of the landing page of the UI.}
+\item{index}{A function that returns the HTML content of the landing page of the UI.
+Parameters (besides \code{req} and \code{res}) will be supplied as if it is a regular \code{GET} route.
+Default parameter values may be used when setting the ui.
+Be sure to see the example below.}
 
 \item{static}{A function that returns the path to the static assets (images, javascript, css, fonts) the UI will use.}
-
-\item{ui}{A list of that plumber can use to mount
-a UI.}
 }
 \description{
-Add UI for plumber to use
-}
-\details{
 \code{\link[=register_ui]{register_ui()}} is used by other packages like \code{swagger}.
 When you load these packages, it calls \code{\link[=register_ui]{register_ui()}} to provide a user
 interface that can interpret your plumber OpenAPI Specifications.
+}
+\examples{
+\dontrun{
+# Example from the `swagger` R package
+register_ui(
+  name = "swagger",
+  index = function(version = "3", ...) {
+    swagger::swagger_spec(
+      api_path = paste0(
+        "window.location.origin + ",
+        "window.location.pathname.replace(",
+          "/\\\\(__swagger__\\\\\\\\/|__swagger__\\\\\\\\/index.html\\\\)$/, \"\"",
+        ") + ",
+        "\"openapi.json\""
+      ),
+      version = version
+    )
+  },
+  static = function(version = "3", ...) {
+    swagger::swagger_path(version)
+  }
+)
+
+# When setting the UI, `index` and `static` function arguments can be supplied
+# * via `pr_set_ui()`
+# * or through URL query string variables
+pr() \%>\%
+  # Set default argument `version = 3` for the swagger `index` and `static` functions
+  pr_set_ui("swagger", version = 3) \%>\%
+  pr_get("/plus/<a:int>/<b:int>", function(a, b) { a + b }) \%>\%
+  pr_run()
+}
 }

--- a/man/register_ui.Rd
+++ b/man/register_ui.Rd
@@ -5,11 +5,17 @@
 \alias{registered_uis}
 \title{Add UI for plumber to use}
 \usage{
-register_ui(ui)
+register_ui(name, index, static)
 
 registered_uis()
 }
 \arguments{
+\item{name}{Name of the UI}
+
+\item{index}{A function that returns the HTML content of the landing page of the UI.}
+
+\item{static}{A function that returns the path to the static assets (images, javascript, css, fonts) the UI will use.}
+
 \item{ui}{A list of that plumber can use to mount
 a UI.}
 }
@@ -20,11 +26,4 @@ Add UI for plumber to use
 \code{\link[=register_ui]{register_ui()}} is used by other packages like \code{swagger}.
 When you load these packages, it calls \code{\link[=register_ui]{register_ui()}} to provide a user
 interface that can interpret your plumber OpenAPI Specifications.
-
-\code{ui} list expects the following values
-\describe{
-\item{name}{Name of the UI.}
-\item{index}{A function that returns the HTML content of the landing page of the UI.}
-\item{static}{A function that returns the path to the static assets (images, javascript, css, fonts) the UI will use.}
-}
 }


### PR DESCRIPTION
`register_ui()` should accept arguments, not a list of arguments.

Going from 

```r
arg_list <- list(
  name = name_val,
  index = index_val,
  static = static_val
)
register_ui(arg_list)
```

to

```r
register_ui(
  name = name_val,
  index = index_val,
  static = static_val
)
```

Chose not to add `verbose` or `overwrite` as these should be done by packages and would always be overwriting.

-------------------

PR task list:
- [NA] Update NEWS
- [NA] Add tests
- [x] Update documentation with `devtools::document()`
