### PR TITLE
Add another situation for no context JSON post body

### DIFF
--- a/R/parse-body.R
+++ b/R/parse-body.R
@@ -42,12 +42,19 @@ parse_raw <- function(toparse) {
   do.call(parser, toparse)
 }
 
+looks_like_json <- local({
+  square_brace <- as.raw(91L)
+  curly_brace <- as.raw(123L)
+  function(first_byte) {
+    first_byte == square_brace || first_byte == curly_brace
+  }
+})
 parser_picker <- function(content_type, first_byte, filename = NULL, parsers = NULL) {
 
   # parse as a query string
   if (length(content_type) == 0) {
     # fast default to json when first byte is 7b (ascii {)
-    if (first_byte == as.raw(123L)) {
+    if (looks_like_json(first_byte)) {
       return(parsers$alias$json)
     }
 

--- a/tests/testthat/test-parse-body.R
+++ b/tests/testthat/test-parse-body.R
@@ -2,6 +2,7 @@ context("POST body")
 
 test_that("JSON is consumed on POST", {
   expect_equal(parse_body('{"a":"1"}', content_type = NULL, parsers = make_parser("json")), list(a = "1"))
+  expect_equal(parse_body('[1,2,3]', content_type = NULL, parsers = make_parser("json")), 1:3)
 })
 
 test_that("ending in `==` does not produce a unexpected key", {


### PR DESCRIPTION
Teasing apart https://github.com/rstudio/plumber/pull/578

Also test for square bracket in addition to the curly bracket

PR task list:
- [NA] Update NEWS
- [x] Add tests
- [x] Update documentation with `devtools::document()`
