### PR TITLE
`parser_octet()` returns a named list of filename to content

### DIFF
--- a/R/parse-body.R
+++ b/R/parse-body.R
@@ -441,12 +441,14 @@ parser_feather <- function(...) {
 
 
 
-#' @describeIn parsers Octet stream parser. Will add a filename attribute if the filename exists
+#' @describeIn parsers Octet stream parser. Will add a filename attribute if the filename exists.
+#'   Returns a single item list where the value is the raw content and the key is the filename (if applicable).
 #' @export
 parser_octet <- function() {
   function(value, filename = NULL, ...) {
-    attr(value, "filename") <- filename
-    value
+    arg <- list(value)
+    names(arg) <- filename
+    return(arg)
   }
 }
 

--- a/man/parsers.Rd
+++ b/man/parsers.Rd
@@ -84,7 +84,8 @@ This parser should be used when reading from a file is required.
 
 \item \code{parser_feather}: feather parser. See \code{\link[feather:read_feather]{feather::read_feather()}} for more details.
 
-\item \code{parser_octet}: Octet stream parser. Will add a filename attribute if the filename exists
+\item \code{parser_octet}: Octet stream parser. Will add a filename attribute if the filename exists.
+Returns a single item list where the value is the raw content and the key is the filename (if applicable).
 
 \item \code{parser_multi}: Multi part parser. This parser will then parse each individual body with its respective parser
 

--- a/tests/testthat/test-parse-body.R
+++ b/tests/testthat/test-parse-body.R
@@ -121,6 +121,7 @@ test_that("Test multipart parser", {
   expect_equal(parsed_body[["rds"]], women)
   expect_equal(names(parsed_body[["img1"]]), c("avatar2-small.png"))
   expect_true(is.raw(parsed_body[["img1"]][["avatar2-small.png"]]))
+  expect_true(length(parsed_body[["img1"]][["avatar2-small.png"]]) > 100)
   expect_equal(parsed_body[["json"]], list(a=2,b=4,c=list(w=3,t=5)))
 })
 

--- a/tests/testthat/test-parse-body.R
+++ b/tests/testthat/test-parse-body.R
@@ -119,7 +119,8 @@ test_that("Test multipart parser", {
 
   expect_equal(names(parsed_body), c("json", "img1", "img2", "rds"))
   expect_equal(parsed_body[["rds"]], women)
-  expect_equal(attr(parsed_body[["img1"]], "filename"), "avatar2-small.png")
+  expect_equal(names(parsed_body[["img1"]]), c("avatar2-small.png"))
+  expect_true(is.raw(parsed_body[["img1"]][["avatar2-small.png"]]))
   expect_equal(parsed_body[["json"]], list(a=2,b=4,c=list(w=3,t=5)))
 })
 

--- a/tests/testthat/test-parser.R
+++ b/tests/testthat/test-parser.R
@@ -67,7 +67,8 @@ test_that("parsers work", {
     })
   expect_equal(names(parsed_body), c("json", "img1", "img2", "rds"))
   expect_equal(parsed_body[["rds"]], women)
-  expect_equal(attr(parsed_body[["img1"]], "filename"), "avatar2-small.png")
+  expect_equal(names(parsed_body[["img1"]]), c("avatar2-small.png"))
+  expect_true(is.raw(parsed_body[["img1"]][["avatar2-small.png"]]))
   expect_equal(parsed_body[["json"]], list(a=2,b=4,c=list(w=3,t=5)))
 
 


### PR DESCRIPTION
Teasing apart https://github.com/rstudio/plumber/pull/578

PR task list:
- [NA] Update NEWS
- [x] Add tests
- [x] Update documentation with `devtools::document()`
