### PR TITLE
Misnamed properties private$filename

### DIFF
--- a/R/plumber.R
+++ b/R/plumber.R
@@ -263,7 +263,7 @@ plumber <- R6Class(
 
       # Set and restore the wd to make it appear that the proc is running local to the file's definition.
       if (!is.null(private$filename)) {
-        old_wd <- setwd(dirname(private$file))
+        old_wd <- setwd(dirname(private$filename))
         on.exit({setwd(old_wd)}, add = TRUE)
       }
 


### PR DESCRIPTION
Go this error while deploying with plumber devtools using entrypoint.

```r
> plumb(dir='api')$run()
Running plumber API at http://0.0.0.0:8004

 Error in dirname(private$file) : a character vector argument expected
7.dirname(private$file)
6.setwd(dirname(private$file))
5.pr$run(host = "0.0.0.0", port = 8004) at entrypoint.R#8
4.eval(exprs, envir)
3.eval(exprs, envir)
2.sourceUTF8(entrypoint, new.env(parent = globalenv()))
1.plumb(dir = "api")
>
```

PR task list:
- [ ] Update NEWS
- [ ] Add tests
- [ ] Update documentation with `devtools::document()`
