### PR TITLE
Add support for Cookie SameSite attribute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -73,6 +73,8 @@ both UIs integration are available from https://github.com/meztez/rapidoc/ and h
 
 ### Minor new features and improvements
 
+* Added support for the `SameSite` Cookie attribute. (#640)
+
 * When calling `include_file()`, the `content_type` is automatically inferred from the file extension if `content_type` is not provided. (#631)
 
 * Added `serializer_feather()` and `parser_feather()` (#626)

--- a/NEWS.md
+++ b/NEWS.md
@@ -73,7 +73,7 @@ both UIs integration are available from https://github.com/meztez/rapidoc/ and h
 
 ### Minor new features and improvements
 
-* Added support for the `SameSite` Cookie attribute. (#640)
+* Added support for the `SameSite` Cookie attribute. (@chris-dudley, #640)
 
 * When calling `include_file()`, the `content_type` is automatically inferred from the file extension if `content_type` is not provided. (#631)
 

--- a/R/plumber-response.R
+++ b/R/plumber-response.R
@@ -34,16 +34,16 @@ PlumberResponse <- R6Class(
       )
     },
     # TODO if name and value are a vector of same length, call set cookie many times
-    setCookie = function(name, value, path, expiration = FALSE, http = FALSE, secure = FALSE) {
-      self$setHeader("Set-Cookie", cookieToStr(name, value, path, expiration, http, secure))
+    setCookie = function(name, value, path, expiration = FALSE, http = FALSE, secure = FALSE, sameSite=FALSE) {
+      self$setHeader("Set-Cookie", cookieToStr(name, value, path, expiration, http, secure, sameSite))
     },
-    removeCookie = function(name, path, http = FALSE, secure = FALSE, ...) {
-      self$setHeader("Set-Cookie", removeCookieStr(name, path, http, secure))
+    removeCookie = function(name, path, http = FALSE, secure = FALSE, sameSite = FALSE, ...) {
+      self$setHeader("Set-Cookie", removeCookieStr(name, path, http, secure, sameSite))
     }
   )
 )
 
-removeCookieStr <- function(name, path, http = FALSE, secure = FALSE) {
+removeCookieStr <- function(name, path, http = FALSE, secure = FALSE, sameSite = FALSE) {
   str <- paste0(name, "=; ")
   if (!missing(path)){
     str <- paste0(str, "Path=", path, "; ")
@@ -54,6 +54,11 @@ removeCookieStr <- function(name, path, http = FALSE, secure = FALSE) {
   if (!missing(secure) && secure){
     str <- paste0(str, "Secure; ")
   }
+
+  if (!missing(sameSite) && is.character(sameSite)) {
+    str <- paste0(str, "SameSite=", sameSite, "; ")
+  }
+
   str <- paste0(str, "Expires=Thu, 01 Jan 1970 00:00:00 GMT")
   str
 }
@@ -66,6 +71,7 @@ cookieToStr <- function(
   expiration = FALSE,
   http = FALSE,
   secure = FALSE,
+  sameSite = FALSE,
   now = Sys.time() # used for testing. Should not be used in regular code.
 ){
   val <- httpuv::encodeURIComponent(as.character(value))
@@ -81,6 +87,10 @@ cookieToStr <- function(
 
   if (!missing(secure) && secure){
     str <- paste0(str, "Secure; ")
+  }
+
+  if (!missing(sameSite) && is.character(sameSite)) {
+    str <- paste0(str, "SameSite=", sameSite, "; ")
   }
 
   if (!missing(expiration)){

--- a/R/pr.R
+++ b/R/pr.R
@@ -345,7 +345,7 @@ pr_hooks <- function(pr,
 #' @param sameSite A character specifying the SameSite policy to attach to the cookie.
 #'   If specified, one of the following values should be given: "Strict", "Lax", or "None".
 #'   If "None" is specified, then the \code{secure} flag MUST also be set for the modern browsers to
-#'   accept the cookie.
+#'   accept the cookie. An error will be returned if \code{sameSite = "None"} and \code{secure = FALSE}.
 #'   If not specified or a non-character is given, no SameSite policy is attached to the cookie.
 #' @seealso \itemize{
 #' \item \href{https://github.com/jeroen/sodium}{'sodium'}: R bindings to 'libsodium'

--- a/R/pr.R
+++ b/R/pr.R
@@ -342,6 +342,11 @@ pr_hooks <- function(pr,
 #'   Defaults to \code{TRUE}.
 #' @param secure Boolean that adds the \code{Secure} cookie flag.  This should be set
 #'   when the route is eventually delivered over \href{https://en.wikipedia.org/wiki/HTTPS}{HTTPS}.
+#' @param sameSite A character specifying the SameSite policy to attach to the cookie.
+#'   If specified, one of the following values should be given: "Strict", "Lax", or "None".
+#'   If "None" is specified, then the \code{secure} flag MUST also be set for the modern browsers to
+#'   accept the cookie.
+#'   If not specified or a non-character is given, no SameSite policy is attached to the cookie.
 #' @seealso \itemize{
 #' \item \href{https://github.com/jeroen/sodium}{'sodium'}: R bindings to 'libsodium'
 #' \item \href{https://download.libsodium.org/doc/}{'libsodium'}: A Modern and Easy-to-Use Crypto Library
@@ -402,10 +407,11 @@ pr_cookie <- function(pr,
                       name = "plumber",
                       expiration = FALSE,
                       http = TRUE,
-                      secure = FALSE) {
+                      secure = FALSE,
+                      sameSite = FALSE) {
   validate_pr(pr)
   pr$registerHooks(
-    sessionCookie(key = key, name = name, expiration = expiration, http = http, secure = secure)
+    sessionCookie(key = key, name = name, expiration = expiration, http = http, secure = secure, sameSite = sameSite)
   )
   invisible(pr)
 }

--- a/R/session-cookie.R
+++ b/R/session-cookie.R
@@ -43,7 +43,7 @@
 #' @param sameSite A character specifying the SameSite policy to attach to the cookie.
 #'   If specified, one of the following values should be given: "Strict", "Lax", or "None".
 #'   If "None" is specified, then the \code{secure} flag MUST also be set for the modern browsers to
-#'   accept the cookie.
+#'   accept the cookie. An error will be returned if \code{sameSite = "None"} and \code{secure = FALSE}.
 #'   If not specified or a non-character is given, no SameSite policy is attached to the cookie.
 #' @export
 #' @seealso \itemize{
@@ -110,7 +110,17 @@ sessionCookie <- function(
   key <- asCookieKey(key)
 
   # force the args to evaluate
-  list(expiration, http, secure)
+  list(expiration, http, secure, sameSite)
+
+  # sanity check the sameSite and secure arguments
+  if (is.character(sameSite)) {
+    sameSite <- match.arg(sameSite, c("Strict", "Lax", "None"))
+  }
+  if (identical(sameSite, "None")) {
+    if (!secure) {
+      stop("You must set secure = TRUE when sameSite is set to 'None'. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie")
+    }
+  }
 
   # Return a list that can be added to registerHooks()
   list(

--- a/R/session-cookie.R
+++ b/R/session-cookie.R
@@ -40,6 +40,11 @@
 #'   Defaults to \code{TRUE}.
 #' @param secure Boolean that adds the \code{Secure} cookie flag.  This should be set
 #'   when the route is eventually delivered over \href{https://en.wikipedia.org/wiki/HTTPS}{HTTPS}.
+#' @param sameSite A character specifying the SameSite policy to attach to the cookie.
+#'   If specified, one of the following values should be given: "Strict", "Lax", or "None".
+#'   If "None" is specified, then the \code{secure} flag MUST also be set for the modern browsers to
+#'   accept the cookie.
+#'   If not specified or a non-character is given, no SameSite policy is attached to the cookie.
 #' @export
 #' @seealso \itemize{
 #' \item \href{https://github.com/jeroen/sodium}{'sodium'}: R bindings to 'libsodium'
@@ -95,7 +100,8 @@ sessionCookie <- function(
   name = "plumber",
   expiration = FALSE,
   http = TRUE,
-  secure = FALSE
+  secure = FALSE,
+  sameSite = FALSE
 ) {
 
   if (missing(key)) {
@@ -129,13 +135,13 @@ sessionCookie <- function(
       session <- req$session
       # save session in a cookie
       if (!is.null(session)) {
-        res$setCookie(name, encodeCookie(session, key), expiration = expiration, http = http, secure = secure)
+        res$setCookie(name, encodeCookie(session, key), expiration = expiration, http = http, secure = secure, sameSite = sameSite)
       } else {
         # session is null
         if (!is.null(req$cookies[[name]])) {
           # no session to save, but had session to parse
           # remove cookie session cookie
-          res$removeCookie(name, "", expiration = expiration, http = http, secure = secure)
+          res$removeCookie(name, "", expiration = expiration, http = http, secure = secure, sameSite = sameSite)
         }
       }
 

--- a/R/session-cookie.R
+++ b/R/session-cookie.R
@@ -115,10 +115,12 @@ sessionCookie <- function(
   # sanity check the sameSite and secure arguments
   if (is.character(sameSite)) {
     sameSite <- match.arg(sameSite, c("Strict", "Lax", "None"))
+  } else {
+    sameSite <- FALSE
   }
   if (identical(sameSite, "None")) {
     if (!secure) {
-      stop("You must set secure = TRUE when sameSite is set to 'None'. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie")
+      stop("You must set `secure = TRUE` when `sameSite = \"None\"`. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie")
     }
   }
 

--- a/man/pr_cookie.Rd
+++ b/man/pr_cookie.Rd
@@ -10,7 +10,8 @@ pr_cookie(
   name = "plumber",
   expiration = FALSE,
   http = TRUE,
-  secure = FALSE
+  secure = FALSE,
+  sameSite = FALSE
 )
 }
 \arguments{
@@ -33,6 +34,12 @@ Defaults to \code{TRUE}.}
 
 \item{secure}{Boolean that adds the \code{Secure} cookie flag.  This should be set
 when the route is eventually delivered over \href{https://en.wikipedia.org/wiki/HTTPS}{HTTPS}.}
+
+\item{sameSite}{A character specifying the SameSite policy to attach to the cookie.
+If specified, one of the following values should be given: "Strict", "Lax", or "None".
+If "None" is specified, then the \code{secure} flag MUST also be set for the modern browsers to
+accept the cookie.
+If not specified or a non-character is given, no SameSite policy is attached to the cookie.}
 }
 \description{
 \code{plumber} uses the crypto R package \code{sodium}, to encrypt/decrypt

--- a/man/pr_cookie.Rd
+++ b/man/pr_cookie.Rd
@@ -38,7 +38,7 @@ when the route is eventually delivered over \href{https://en.wikipedia.org/wiki/
 \item{sameSite}{A character specifying the SameSite policy to attach to the cookie.
 If specified, one of the following values should be given: "Strict", "Lax", or "None".
 If "None" is specified, then the \code{secure} flag MUST also be set for the modern browsers to
-accept the cookie.
+accept the cookie. An error will be returned if \code{sameSite = "None"} and \code{secure = FALSE}.
 If not specified or a non-character is given, no SameSite policy is attached to the cookie.}
 }
 \description{

--- a/man/sessionCookie.Rd
+++ b/man/sessionCookie.Rd
@@ -9,7 +9,8 @@ sessionCookie(
   name = "plumber",
   expiration = FALSE,
   http = TRUE,
-  secure = FALSE
+  secure = FALSE,
+  sameSite = FALSE
 )
 }
 \arguments{
@@ -30,6 +31,12 @@ Defaults to \code{TRUE}.}
 
 \item{secure}{Boolean that adds the \code{Secure} cookie flag.  This should be set
 when the route is eventually delivered over \href{https://en.wikipedia.org/wiki/HTTPS}{HTTPS}.}
+
+\item{sameSite}{A character specifying the SameSite policy to attach to the cookie.
+If specified, one of the following values should be given: "Strict", "Lax", or "None".
+If "None" is specified, then the \code{secure} flag MUST also be set for the modern browsers to
+accept the cookie.
+If not specified or a non-character is given, no SameSite policy is attached to the cookie.}
 }
 \description{
 \code{plumber} uses the crypto R package \code{sodium}, to encrypt/decrypt

--- a/man/sessionCookie.Rd
+++ b/man/sessionCookie.Rd
@@ -35,7 +35,7 @@ when the route is eventually delivered over \href{https://en.wikipedia.org/wiki/
 \item{sameSite}{A character specifying the SameSite policy to attach to the cookie.
 If specified, one of the following values should be given: "Strict", "Lax", or "None".
 If "None" is specified, then the \code{secure} flag MUST also be set for the modern browsers to
-accept the cookie.
+accept the cookie. An error will be returned if \code{sameSite = "None"} and \code{secure = FALSE}.
 If not specified or a non-character is given, no SameSite policy is attached to the cookie.}
 }
 \description{

--- a/tests/testthat/test-cookies.R
+++ b/tests/testthat/test-cookies.R
@@ -51,6 +51,7 @@ test_that("cookies can convert to string", {
   expect_equal(cookieToStr("complex2", "forbidden:,%/"), "complex2=forbidden%3A%2C%25%2F")
   expect_equal(cookieToStr("abc", 123, path="/somepath"), "abc=123; Path=/somepath")
   expect_equal(cookieToStr("abc", 123, http=TRUE, secure=TRUE), "abc=123; HttpOnly; Secure")
+  expect_equal(cookieToStr("abc", 123, http=TRUE, secure=TRUE, sameSite="None"), "abc=123; HttpOnly; Secure; SameSite=None")
 
   now <- force(Sys.time())
   cookieToStr_ <- function(expiration, ...) {
@@ -100,6 +101,10 @@ test_that("remove cookie string works", {
   expect_equal(
     removeCookieStr("asdf", path = "/", http = TRUE, secure = TRUE),
     "asdf=; Path=/; HttpOnly; Secure; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+  )
+  expect_equal(
+    removeCookieStr("asdf", path = "/", http = TRUE, secure = TRUE, sameSite = "None"),
+    "asdf=; Path=/; HttpOnly; Secure; SameSite=None; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
   )
 })
 

--- a/tests/testthat/test-response.R
+++ b/tests/testthat/test-response.R
@@ -37,3 +37,10 @@ test_that("can set multiple same-named headers", {
   expect_true(test)
   expect_true(another)
 })
+
+test_that("response properly sets cookies with multiple options", {
+  res <- PlumberResponse$new()
+  res$setCookie("abc", "two words", http=TRUE, secure=TRUE, sameSite="None")
+  head <- res$toResponse()$headers
+  expect_equal(head[["Set-Cookie"]], "abc=two%20words; HttpOnly; Secure; SameSite=None")
+})


### PR DESCRIPTION
Adds an optional `sameSite` attribute to the following functions:

- `sessionCookie()`
- `pr_cookie()`
- `res$setCookie()`
- `res$removeCookie()`
- `removeCookieStr`
- `cookieToStr`

If set to a character value `<value>`, the generated cookie will contain a `SameSite=<value>` attribute.

Fixes #640 

Allows the SameSite attribute to be set on cookies. This is especially important for Cross-Origin requests, as in the near future browsers will automatically default to the "SameSite=Lax" policy for cookies without an explicit policy set. This will prevent cookies from being sent on Cross-Origin requests unless the policy is set to "None".

See:
- https://www.chromestatus.com/feature/5088147346030592
- https://www.chromestatus.com/feature/5633521622188032