### PR TITLE
Fix vignette plot `pts` to positive range

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -128,6 +128,7 @@ both UIs integration are available from https://github.com/meztez/rapidoc/ and h
 
 * Added support for swagger for mounted routers (@bradleyhd, #274).
 
+* Updated security vignette: Prevent large plots with more than 1000 points.
 
 ### Bug fixes
 

--- a/vignettes/files/apis/07-02-plot-safe.R
+++ b/vignettes/files/apis/07-02-plot-safe.R
@@ -3,8 +3,8 @@
 #' @get /
 #' @serializer png
 function(pts=10) {
-  if (pts > 1000){
-    stop("pts must be < 1,000")
+  if (pts > 1000 & pts > 0){
+    stop("pts must be between 1 and 1,000")
   }
 
   plot(1:pts)


### PR DESCRIPTION
In the security vignette, where you restricted the plot to consist of less than 1000 points it was possible to crash the R process when entering a high negative number. 

Now, this function will not accept negative values, preventing the r process to crash. 

PR task list:
- [x] Update NEWS
- [ ] Add tests
- [x] Update documentation with `devtools::document()`
