### PR TITLE
Host all api docs at `__docs__`

### DIFF
--- a/R/pr_set.R
+++ b/R/pr_set.R
@@ -130,7 +130,7 @@ pr_set_debug <- function(pr, debug = interactive()) {
 #' When `TRUE` or a
 #' function, multiple handles will be added to [`Plumber`] object. OpenAPI json
 #' file will be served on paths `/openapi.json` and `/swagger.json`. Swagger UI
-#' will be served on paths `/__swagger__/index.html` and `/__swagger__/`. When
+#' will be served on paths `/__docs__/index.html` and `/__docs__/`. When
 #' using a function, it will receive the Plumber router as the first parameter
 #' and current OpenAPI Specification as the second. This function should return a
 #' list containing OpenAPI Specification.

--- a/R/ui.R
+++ b/R/ui.R
@@ -9,6 +9,11 @@ mount_ui <- function(pr, host, port, ui_info, callback) {
     return()
   }
 
+  if (isTRUE(ui_info$ui == "swagger")) {
+    # force the .onLoad method to occur
+    require(swagger)
+  }
+
   # Build api url
   api_url <- getOption(
     "plumber.apiURL",
@@ -151,7 +156,7 @@ unmount_openapi <- function(pr) {
 #'       api_path = paste0(
 #'         "window.location.origin + ",
 #'         "window.location.pathname.replace(",
-#'           "/\\(__swagger__\\\\/|__swagger__\\\\/index.html\\)$/, \"\"",
+#'           "/\\(__docs__\\\\/|__docs__\\\\/index.html\\)$/, \"\"",
 #'         ") + ",
 #'         "\"openapi.json\""
 #'       ),
@@ -180,7 +185,9 @@ register_ui <- function(name, index, static = NULL) {
   stopifnot(is.function(index))
   if (!is.null(static)) stopifnot(is.function(static))
 
-  ui_root <- paste0("/__", name, "__/")
+  is_swagger <- isTRUE(name == "swagger")
+
+  ui_root <- paste0("/__docs__/")
   ui_paths <- c("/index.html", "/")
 
   mount_ui_func <- function(pr, api_url, ...) {
@@ -211,11 +218,27 @@ register_ui <- function(name, index, static = NULL) {
 
     pr$mount(ui_root, ui_router)
 
+    # add legacy swagger redirects
+    if (is_swagger) {
+      redirect_info <- swagger_redirects()
+      for (path in names(redirect_info)) {
+        pr_get(pr, path, redirect_info[[path]])
+      }
+    }
+
     ui_url <- paste0(api_url, ui_root)
     return(ui_url)
   }
   unmount_ui_func <- function(pr) {
     pr$unmount(ui_root)
+
+    # remove legacy swagger redirects
+    if (is_swagger) {
+      redirect_info <- swagger_redirects()
+      for (path in names(redirect_info)) {
+        pr$removeHandle("GET", path)
+      }
+    }
     invisible()
   }
 
@@ -233,21 +256,18 @@ registered_uis <- function() {
   sort(names(.globals$UIs))
 }
 
-# TODO: Remove once UI load code moved to respective UI package
-swagger_ui <- list(
-  name = "swagger",
-  index = function(version = "3", ...) {
-    swagger::swagger_spec(
-      api_path = 'window.location.origin + window.location.pathname.replace(/\\(__swagger__\\\\/|__swagger__\\\\/index.html\\)$/, "") + "openapi.json"',
-      version = version
-    )
-  },
-  static = function(version = "3", ...) {
-    swagger::swagger_path(version)
-  }
-)
 
-#' @noRd
-register_uis_onLoad <- function() {
-  register_ui(swagger_ui$name, swagger_ui$index, swagger_ui$static)
+swagger_redirects <- function() {
+  to_route <- function(route) {
+    function(req, res) {
+      res$status <- 303 # redirect permanently
+      res$setHeader("Location", route)
+      res$body <- "redirecting..."
+      res
+    }
+  }
+  list(
+    "/__swagger__/" = to_route("../__docs__/"),
+    "/__swagger__/index.html"  = to_route("../__docs__/index.html")
+  )
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,9 +5,6 @@
 
   register_parsers_onLoad()
 
-  # TODO: Remove once UI load code moved to respective UI package
-  register_uis_onLoad()
-
   add_serializers_onLoad()
 
 }

--- a/man/pr_set_ui.Rd
+++ b/man/pr_set_ui.Rd
@@ -22,7 +22,7 @@ The Plumber router with the new UI settings.
 When \code{TRUE} or a
 function, multiple handles will be added to \code{\link{Plumber}} object. OpenAPI json
 file will be served on paths \verb{/openapi.json} and \verb{/swagger.json}. Swagger UI
-will be served on paths \verb{/__swagger__/index.html} and \verb{/__swagger__/}. When
+will be served on paths \verb{/__docs__/index.html} and \verb{/__docs__/}. When
 using a function, it will receive the Plumber router as the first parameter
 and current OpenAPI Specification as the second. This function should return a
 list containing OpenAPI Specification.

--- a/man/register_ui.Rd
+++ b/man/register_ui.Rd
@@ -34,7 +34,7 @@ register_ui(
       api_path = paste0(
         "window.location.origin + ",
         "window.location.pathname.replace(",
-          "/\\\\(__swagger__\\\\\\\\/|__swagger__\\\\\\\\/index.html\\\\)$/, \"\"",
+          "/\\\\(__docs__\\\\\\\\/|__docs__\\\\\\\\/index.html\\\\)$/, \"\"",
         ") + ",
         "\"openapi.json\""
       ),

--- a/scripts/manual_testing.R
+++ b/scripts/manual_testing.R
@@ -19,8 +19,8 @@ test_that("custom OpenAPI Specification update function works", {
   # Should get a message that wribbit is unknown if library is not loaded
   pr$run(port = 1234)
 
-  # validate that http://127.0.0.1:1234/__swagger__/ displays the system time as the api title
-  # http://127.0.0.1:1234/__swagger__/
+  # validate that http://127.0.0.1:1234/__docs__/ displays the system time as the api title
+  # http://127.0.0.1:1234/__docs__/
   pr$setUi(ui = TRUE)
   pr$run(port = 1234)
   pr$setUi(ui = "swagger")
@@ -39,17 +39,17 @@ test_that("host doesn't change for messages, but does for RStudio IDE", {
     "0.0.0.0", port = 1234
   )
   #> Running plumber API at http://0.0.0.0:1234
-  #> Running Swagger UI  at http://127.0.0.1:1234/__swagger__/
+  #> Running Swagger UI  at http://127.0.0.1:1234/__docs__/
 
   pr$run(
     "::", port = 1234
   )
   #> Running plumber API at http://[::]:1234
-  #> Running Swagger UI  at http://[::1]:1234/__swagger__/
+  #> Running Swagger UI  at http://[::1]:1234/__docs__/
 
 
   # Verify that the output matches the output above.
-  # if in RStudio IDE, verify that the window opened, opens to http://127.0.0.1:1234/__swagger__/ or http://[::1]:1234/__swagger__/
-  # verify that the swagger route (from messages) works in a web browser http://127.0.0.1:1234/__swagger__/ or http://[::1]:1234/__swagger__/
+  # if in RStudio IDE, verify that the window opened, opens to http://127.0.0.1:1234/__docs__/ or http://[::1]:1234/__docs__/
+  # verify that the swagger route (from messages) works in a web browser http://127.0.0.1:1234/__docs__/ or http://[::1]:1234/__docs__/
   # Verify that http://0.0.0.0/tail or http://[::1]:1234/tail executes
 })


### PR DESCRIPTION
Fixes #646 

In coordination with https://github.com/rstudio/swagger/pull/13

* If docs name is `swagger`, add redirects and remove redirects.

PR task list:
- [ ] Update NEWS
- [NA] Add tests
- [x] Update documentation with `devtools::document()`
