### PR TITLE
Multipart body followup

### DIFF
--- a/R/parse-body.R
+++ b/R/parse-body.R
@@ -20,7 +20,14 @@ req_body_parser <- function(req, parsers = NULL) {
   if (is.null(bodyRaw)) {return(list())}
   body <- parse_body(bodyRaw, type, parsers)
   # store parsed body into req$body
-  req$body <- body
+  body
+}
+req_body_args <- function(req) {
+
+  body <- req$body
+  if (length(body) == 0) {
+    return(list())
+  }
 
   # Copy name over so that it is clearer as to the goal of the code below
   # The value returned from this function is set to `ret$argsBody`

--- a/R/parse-body.R
+++ b/R/parse-body.R
@@ -14,10 +14,14 @@ bodyFilter <- function(req){
 }
 
 req_body_parser <- function(req, parsers = NULL) {
-  if (length(parsers) == 0) {return(list())}
+  if (length(parsers) == 0) {
+    return(NULL)
+  }
   type <- req$HTTP_CONTENT_TYPE
   bodyRaw <- req$bodyRaw
-  if (is.null(bodyRaw)) {return(list())}
+  if (is.null(bodyRaw)) {
+    return(NULL)
+  }
   body <- parse_body(bodyRaw, type, parsers)
   # store parsed body into req$body
   body

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -610,7 +610,8 @@ Plumber <- R6Class(
             }
           req$argsPath <- h$getPathParams(path)
           # `req_body_parser()` will also set `req$body` with the untouched body value
-          req$argsBody <- req_body_parser(req, parsers)
+          req$body <- req_body_parser(req, parsers)
+          req$argsBody <- req_body_args(req)
 
           req$args <- c(
             # req, res


### PR DESCRIPTION
Related: #663 

* Make it so `req_body_parser` doesn't set info in `req` and also return a value

PR task list:
- [NA] Update NEWS
- [x] Add tests
- [x] Update documentation with `devtools::document()`
