### PR TITLE
Add peer dependency which npm does not install by default

### DIFF
--- a/inst/validate_api_spec/package.json
+++ b/inst/validate_api_spec/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "devDependencies": {
-    "swagger-cli": "^4.0.4"
+    "swagger-cli": "^4.0.4",
+    "openapi-types": ">=7"
   }
 }


### PR DESCRIPTION
Removes message from testing:

```
npm WARN @apidevtools/swagger-parser@10.0.2 requires a peer of openapi-types@>=7 but none is installed. You must install peer dependencies yourself.
```

PR task list:
- [NA] Update NEWS
- [NA] Add tests
- [NA] Update documentation with `devtools::document()`
