### PR TITLE
remove `debug` argument from `pr_run` example

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -482,7 +482,7 @@ pr_filter <- function(pr,
 #'   pr_run()
 #'
 #' pr() %>%
-#'   pr_run(port = 5762, debug = TRUE)
+#'   pr_run(port = 5762)
 #' }
 #'
 #' @export

--- a/man/pr_run.Rd
+++ b/man/pr_run.Rd
@@ -26,7 +26,7 @@ pr() \%>\%
   pr_run()
 
 pr() \%>\%
-  pr_run(port = 5762, debug = TRUE)
+  pr_run(port = 5762)
 }
 
 }


### PR DESCRIPTION
I updated a small chunk of the `pr_run` documentation.  Wasn't sure if that warranted an update of NEWS (nor do I know where to put it if it did.)