### PR TITLE
Provide arg names to all PlumberEndpoint variables in pr$handle()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: plumber
 Type: Package
 Title: An API Generator for R
-Version: 1.0.0
+Version: 1.0.0.9999
 Roxygen: list(markdown = TRUE)
 Authors@R: c(
   person("Barret", "Schloerke", role = c("cre", "aut"), email = "barret@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ plumber 1.0.0.9999 Development version
 
 ### Bug fixes
 
-* Something about how handle deals with ... in relation to PlumberEndpoint
+* When manually calling `Plumber$handle()`, `envir` may not be passed through when defining a new `PlumberEndpoint` #677  
 
 plumber 1.0.0
 --------------------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+plumber 1.0.0.9999 Development version
+--------------------------------------------------------------------------------
+
+### Bug fixes
+
+* Something about how handle deals with ... in relation to PlumberEndpoint
+
 plumber 1.0.0
 --------------------------------------------------------------------------------
 

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -332,8 +332,7 @@ Plumber <- R6Class(
     #' @param serializer a serializer function.
     #' @param parsers a named list of parsers.
     #' @param endpoint a `PlumberEndpoint` object.
-    #' @param environment an R environment where to evaluate handle handler.
-    #' @param ... additional arguments for [PlumberEndpoint] `new` method (namely `lines`, `params`, `comments`, `responses` and `tags`).
+    #' @param ... additional arguments for [PlumberEndpoint] `new` method (namely `lines`, `params`, `comments`, `responses` and `tags`. Excludes `envir`).
     #' @examples
     #' \dontrun{
     #' pr <- pr()
@@ -341,7 +340,7 @@ Plumber <- R6Class(
     #'   "<html><h1>Programmatic Plumber!</h1></html>"
     #' }, serializer=plumber::serializer_html())
     #' }
-    handle = function(methods, path, handler, preempt, serializer, parsers, endpoint, environment, ...) {
+    handle = function(methods, path, handler, preempt, serializer, parsers, endpoint, ...) {
       epdef <- !missing(methods) || !missing(path) || !missing(handler) || !missing(serializer) || !missing(parsers)
       if (!missing(endpoint) && epdef) {
         stop("You must provide either the components for an endpoint (handler and serializer) OR provide the endpoint yourself. You cannot do both.")
@@ -354,14 +353,14 @@ Plumber <- R6Class(
         if (missing(parsers)) {
           parsers <- private$parsers
         }
-        if (missing(environment)) {
-          environment <- private$envir
+        if ("envir" %in% names(list(...))) {
+          stop("`envir` can not be supplied to `pr$handle()`")
         }
 
         endpoint <- PlumberEndpoint$new(verbs = methods,
                                         path = path,
                                         expr = handler,
-                                        envir = environment,
+                                        envir = private$envir,
                                         serializer = serializer,
                                         parsers = parsers, ...)
       }

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -353,8 +353,10 @@ Plumber <- R6Class(
         if (missing(parsers)) {
           parsers <- private$parsers
         }
-        if ("envir" %in% names(list(...))) {
-          stop("`envir` can not be supplied to `pr$handle()`")
+        forbid <- c("verbs", "expr", "envir")
+        forbid_check <- forbid %in% names(list(...))
+        if (any(forbid_check)) {
+          stop(paste0("`", forbid[forbid_check], "`", collapse = ", "), " can not be supplied to `pr$handle()` method.")
         }
 
         endpoint <- PlumberEndpoint$new(verbs = methods,

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -332,7 +332,8 @@ Plumber <- R6Class(
     #' @param serializer a serializer function.
     #' @param parsers a named list of parsers.
     #' @param endpoint a `PlumberEndpoint` object.
-    #' @param ... additional arguments for `PlumberEndpoint` creation
+    #' @param environment an R environment where to evaluate handle handler.
+    #' @param ... additional arguments for [PlumberEndpoint] `new` method (namely `lines`, `params`, `comments`, `responses` and `tags`).
     #' @examples
     #' \dontrun{
     #' pr <- pr()
@@ -340,9 +341,9 @@ Plumber <- R6Class(
     #'   "<html><h1>Programmatic Plumber!</h1></html>"
     #' }, serializer=plumber::serializer_html())
     #' }
-    handle = function(methods, path, handler, preempt, serializer, parsers, endpoint, ...) {
+    handle = function(methods, path, handler, preempt, serializer, parsers, endpoint, environment, ...) {
       epdef <- !missing(methods) || !missing(path) || !missing(handler) || !missing(serializer) || !missing(parsers)
-      if (!missing(endpoint) && epdef){
+      if (!missing(endpoint) && epdef) {
         stop("You must provide either the components for an endpoint (handler and serializer) OR provide the endpoint yourself. You cannot do both.")
       }
 
@@ -353,8 +354,16 @@ Plumber <- R6Class(
         if (missing(parsers)) {
           parsers <- private$parsers
         }
+        if (missing(environment)) {
+          environment <- private$envir
+        }
 
-        endpoint <- PlumberEndpoint$new(methods, path, handler, private$envir, serializer, parsers, ...)
+        endpoint <- PlumberEndpoint$new(verbs = methods,
+                                        path = path,
+                                        expr = handler,
+                                        envir = environment,
+                                        serializer = serializer,
+                                        parsers = parsers, ...)
       }
       private$addEndpointInternal(endpoint, preempt)
     },

--- a/man/Plumber.Rd
+++ b/man/Plumber.Rd
@@ -400,7 +400,6 @@ See also: \code{\link[=pr_handle]{pr_handle()}}, \code{\link[=pr_get]{pr_get()}}
   serializer,
   parsers,
   endpoint,
-  environment,
   ...
 )}\if{html}{\out{</div>}}
 }
@@ -422,9 +421,7 @@ See also: \code{\link[=pr_handle]{pr_handle()}}, \code{\link[=pr_get]{pr_get()}}
 
 \item{\code{endpoint}}{a \code{PlumberEndpoint} object.}
 
-\item{\code{environment}}{an R environment where to evaluate handle handler.}
-
-\item{\code{...}}{additional arguments for \link{PlumberEndpoint} \code{new} method (namely \code{lines}, \code{params}, \code{comments}, \code{responses} and \code{tags}).}
+\item{\code{...}}{additional arguments for \link{PlumberEndpoint} \code{new} method (namely \code{lines}, \code{params}, \code{comments}, \code{responses} and \code{tags}. Excludes \code{envir}).}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Plumber.Rd
+++ b/man/Plumber.Rd
@@ -400,6 +400,7 @@ See also: \code{\link[=pr_handle]{pr_handle()}}, \code{\link[=pr_get]{pr_get()}}
   serializer,
   parsers,
   endpoint,
+  environment,
   ...
 )}\if{html}{\out{</div>}}
 }
@@ -421,7 +422,9 @@ See also: \code{\link[=pr_handle]{pr_handle()}}, \code{\link[=pr_get]{pr_get()}}
 
 \item{\code{endpoint}}{a \code{PlumberEndpoint} object.}
 
-\item{\code{...}}{additional arguments for \code{PlumberEndpoint} creation}
+\item{\code{environment}}{an R environment where to evaluate handle handler.}
+
+\item{\code{...}}{additional arguments for \link{PlumberEndpoint} \code{new} method (namely \code{lines}, \code{params}, \code{comments}, \code{responses} and \code{tags}).}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -523,3 +523,13 @@ test_that("routes that don't start with a slash are prepended with a slash", {
   expect_equal(length(pr$endpoints[[1]]), 1L)
   expect_equal(pr$endpoints[[1]][[1]]$path, "/nested/path/here")
 })
+
+test_that("handle method rejects forbidden arguments", {
+  pr <- pr()
+  expect_error(pr$handle("GET", "nested/path/here", function(){}, envir = new.env()),
+               "can not be supplied to", )
+  expect_error(pr$handle("GET", "nested/path/here", function(){}, verbs = "GET"),
+               "can not be supplied to")
+  expect_error(pr$handle("GET", "nested/path/here", function(){}, expr = function(){}),
+               "can not be supplied to")
+})


### PR DESCRIPTION
* Throws if `envir` is supplied to `pr$handle()`

Fixes #676 

PR task list:
- [x] Update NEWS
- [x] Add tests
- [x] Update documentation with `devtools::document()`
