### PR TITLE
Use `dev_set()` helper method

### DIFF
--- a/R/serializer.R
+++ b/R/serializer.R
@@ -652,8 +652,8 @@ createGraphicsDevicePromiseDomain <- function(which = dev.cur()) {
       force(onFulfilled)
       function(...) {
         old <- dev.cur()
-        dev.set(which)
-        on.exit(dev.set(old))
+        dev_set(which)
+        on.exit(dev_set(old))
 
         onFulfilled(...)
       }
@@ -662,18 +662,25 @@ createGraphicsDevicePromiseDomain <- function(which = dev.cur()) {
       force(onRejected)
       function(...) {
         old <- dev.cur()
-        dev.set(which)
-        on.exit(dev.set(old))
+        dev_set(which)
+        on.exit(dev_set(old))
 
         onRejected(...)
       }
     },
     wrapSync = function(expr) {
       old <- dev.cur()
-      dev.set(which)
-      on.exit(dev.set(old))
+      dev_set(which)
+      on.exit(dev_set(old))
 
       force(expr)
     }
   )
+}
+    
+dev_set <- function(i) {
+  # make sure to not open a device when calling `dev.set(1)`
+  if (i > 1) {
+    dev.set(i)
+  }
 }

--- a/R/serializer.R
+++ b/R/serializer.R
@@ -647,6 +647,13 @@ add_serializers_onLoad <- function() {
 createGraphicsDevicePromiseDomain <- function(which = dev.cur()) {
   force(which)
 
+  if (which < 2) {
+    stop(
+      "`createGraphicsDevicePromiseDomain()` was called without opening a device first.",
+      " Open a new graphics device before calling."
+    )
+  }
+
   promises::new_promise_domain(
     wrapOnFulfilled = function(onFulfilled) {
       force(onFulfilled)
@@ -677,10 +684,12 @@ createGraphicsDevicePromiseDomain <- function(which = dev.cur()) {
     }
   )
 }
-    
+
 dev_set <- function(i) {
-  # make sure to not open a device when calling `dev.set(1)`
+  # make sure to not open a new device when calling `dev.set(1)`
   if (i > 1) {
     dev.set(i)
+  } else {
+    warning("Can not set `.Device` to the `null device`. Was `dev.off()` manually called?")
   }
 }

--- a/tests/testthat/test-serializer-device.R
+++ b/tests/testthat/test-serializer-device.R
@@ -1,8 +1,29 @@
-# Only test on CI
-skip_on_cran()
-
 context("device serializer")
 
+test_that("graphics device promise domains must have a device", {
+  expect_error(
+    # send in a value that is returned for a null device
+    createGraphicsDevicePromiseDomain(which = c(`null device` = 1L)),
+    "was called without opening a device"
+  )
+})
+
+test_that("you should not call `dev_set()` with a null device", {
+
+  expect_warning(
+    # send in a value that is returned for a null device
+    dev_set(c(`null device` = 1L)),
+    "null device"
+  )
+})
+
+
+
+
+
+
+# Only test on CI
+skip_on_cran()
 
 expect_device_output <- function(name, content_type, capability_type = name) {
 


### PR DESCRIPTION
avoid opening a new device when setting to the NULL device.

Learned via thematic

PR task list:
- [NA] Update NEWS
- [x] Add tests
- [NA] Update documentation with `devtools::document()`
