### PR TITLE
Fix the description of $setHeader() in rendering-output.Rmd

### DIFF
--- a/vignettes/rendering-output.Rmd
+++ b/vignettes/rendering-output.Rmd
@@ -31,7 +31,7 @@ Name | Example | Description
 ---- | ------- | -----------------------
 `setCookie` | `res$setCookie("foo", "bar")` | Sets an HTTP cookie on the client
 `removeCookie` | `res$removeCookie("foo")` | Removes an HTTP cookie
-`setHeader` | `res$setHeader(foo = "bar")` | Sets a header that's available in `res$headers`
+`setHeader` | `res$setHeader("foo", "bar")` | Sets an HTTP header
 `toResponse` | `res$toResponse()` | Renders the response object as a list containing `status`, `headers`, and `body`.
 
 The other methods (`clone`, `initialize`, and `serializer`) should not be directly invoked on the response object.


### PR DESCRIPTION
The description of the argument of `$setHeader()` was (slightly) wrong. Also `that's available in res$headers` suggests to me that it can only change existing headers, but that is not the case.
