### PR TITLE
Fix available apis printing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ plumber 1.0.0.9999 Development version
 
 * `/__swagger__/` now always redirect to `/__docs__/`, even when Swagger isn't the selected interface. Use `options(plumber.legacyRedirects = FALSE)` to disable this behavior (@blairj09 #694)
 
+* Fixed `available_apis()` bug where all packages printed all available APIs (@meztez #708)
+
 
 plumber 1.0.0
 --------------------------------------------------------------------------------

--- a/R/plumb.R
+++ b/R/plumb.R
@@ -271,7 +271,7 @@ format.plumber_available_apis <- function(x, ...) {
     function(apis_sub) {
       paste0(
         "* ", apis_sub$package[1], "\n",
-        paste0("  - ", apis$name, collapse = "\n")
+        paste0("  - ", apis_sub$name, collapse = "\n")
       )
     },
     character(1)

--- a/tests/testthat/test-zzz-plumb_api.R
+++ b/tests/testthat/test-zzz-plumb_api.R
@@ -32,6 +32,32 @@ test_that("available_apis() print method works", {
     expected_apis_output
   )
 })
+test_that("available_apis() print method works with two packages", {
+  top <- available_apis("plumber")
+  bottom <- top
+  top$package <- "top"
+  bottom$package <- "bottom"
+
+  apis_output <- capture.output({
+    rbind(top, bottom)
+  })
+
+  plumber_apis <- paste0("  - ", dir(system.file("plumber", package = "plumber")))
+
+  # printed in alpha order
+  expected_apis_output <- c(
+    "Available Plumber APIs:",
+    "* bottom",
+    plumber_apis,
+    "* top",
+    plumber_apis
+  )
+
+  expect_equal(
+    apis_output,
+    expected_apis_output
+  )
+})
 
 test_that("missing args are handled", {
   expect_equal(plumb_api("plumber", NULL), available_apis("plumber"))

--- a/tests/testthat/test-zzz-plumb_api.R
+++ b/tests/testthat/test-zzz-plumb_api.R
@@ -94,18 +94,24 @@ test_that("edit opens correct file", {
 
   selected_api <- apis$package == "plumber" & apis$name == "01-append"
 
-  expect_output(
-  	plumb_api("plumber", "01-append", edit = TRUE),
-    "plumber.R test file attempted to open",
-    fixed = TRUE
+  expect_warning(
+    expect_output(
+      plumb_api("plumber", "01-append", edit = TRUE),
+      "plumber.R test file attempted to open",
+      fixed = TRUE
+    ),
+    "plumber.R has been opened in the editor"
   )
 
   selected_api <- apis$package == "plumber" & apis$name == "12-entrypoint"
 
-  expect_output(
-    plumb_api("plumber", "12-entrypoint", edit = TRUE),
-    "entrypoint.R test file attempted to open",
-    fixed = TRUE
+  expect_warning(
+    expect_output(
+      plumb_api("plumber", "12-entrypoint", edit = TRUE),
+      "entrypoint.R test file attempted to open",
+      fixed = TRUE
+    ),
+    "entrypoint.R has been opened in the editor"
   )
 })
 


### PR DESCRIPTION
Misnamed reference in `vapply`

Fixes #706

PR task list:
- [x] Update NEWS
- [NA] Add tests
- [x] Update documentation with `devtools::document()`
