### PR TITLE
Add Plumber$flags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,12 +5,14 @@ plumber 1.0.0.9999 Development version
 
 * Force json serialization of endpoint error responses instead of using endpoint serializer. (@meztez, #689)
 
+* When plumbing a Plumber file and using a Plumber router modifier (`#* @plumber`), an error will be thrown if the original router is not returned. (#738)
+
 ### New features
 
-* Guess OpenApi response content type from serializer (@meztez #684)
+* Guess OpenApi response content type from serializer. (@meztez #684)
 
-* Passing `edit = TRUE` to `plumb_api()` will open the API source file (#699)
-* Allow for spaces in `@apiTag` and `@tag` when tag is surrended by single or double quotes (#685)
+* Passing `edit = TRUE` to `plumb_api()` will open the API source file. (#699)
+* Allow for spaces in `@apiTag` and `@tag` when tag is surrended by single or double quotes. (#685)
 
 * OpenAPI Specification can be set using a file path. (@meztez #696)
 
@@ -20,13 +22,16 @@ plumber 1.0.0.9999 Development version
 
 * Block parsing comments, tags and responses ordering match plumber api ordering. (#722)
 
-* When calling `Plumber$handle()` and defining a new `PlumberEndpoint`, `...` will be checked for invalid names (@meztez, #677)
+* When calling `Plumber$handle()` and defining a new `PlumberEndpoint`, `...` will be checked for invalid names. (@meztez, #677)
 
-* `/__swagger__/` now always redirect to `/__docs__/`, even when Swagger isn't the selected interface. Use `options(plumber.legacyRedirects = FALSE)` to disable this behavior (@blairj09 #694)
+* `/__swagger__/` now always redirect to `/__docs__/`, even when Swagger isn't the selected interface. Use `options(plumber.legacyRedirects = FALSE)` to disable this behavior. (@blairj09 #694)
 
-* Fixed `available_apis()` bug where all packages printed all available APIs (@meztez #708)
+* Fixed `available_apis()` bug where all packages printed all available APIs. (@meztez #708)
 
-* Fix Plumber `$routes` resolution bugs. Also return routes in lexicographical order. (@meztez #702)
+* Fixed Plumber `$routes` resolution bugs. Routes are now returned in lexicographical order. (@meztez #702)
+
+* Plumber will now display a circular reference if one is found while printing. (#738)
+
 
 plumber 1.0.0
 --------------------------------------------------------------------------------

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -390,6 +390,23 @@ Plumber <- R6Class(
       if (!topLevel){
         cat("\u2502 ") # "| "
       }
+
+      # Avoid printing recursion (mount on mount on mount on ...)
+      if (!isTRUE(topLevel)) {
+        if (isTRUE(private$flags$is_printing)) {
+          cat(
+            crayon::bgYellow(
+              crayon::black(
+                "# Circular Plumber router definition detected")),
+            "\n", sep=""
+          )
+          return()
+        }
+        # set flags to avoid inf recursion
+        on.exit({ private$flags$is_printing <- NULL }, add = TRUE)
+        private$flags$is_printing <- TRUE
+      }
+
       cat(crayon::silver("# Plumber router with ", endCount, " endpoint", ifelse(endCount == 1, "", "s"),", ",
                          as.character(length(private$filts)), " filter", ifelse(length(private$filts) == 1, "", "s"),", and ",
                          as.character(length(self$mounts)), " sub-router", ifelse(length(self$mounts) == 1, "", "s"),".\n", sep=""))

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -393,7 +393,7 @@ Plumber <- R6Class(
 
       # Avoid printing recursion (mount on mount on mount on ...)
       if (!isTRUE(topLevel)) {
-        if (isTRUE(private$flags$is_printing)) {
+        if (isTRUE(self$flags$is_printing)) {
           cat(
             crayon::bgYellow(
               crayon::black(
@@ -403,8 +403,8 @@ Plumber <- R6Class(
           return()
         }
         # set flags to avoid inf recursion
-        on.exit({ private$flags$is_printing <- NULL }, add = TRUE)
-        private$flags$is_printing <- TRUE
+        on.exit({ self$flags$is_printing <- NULL }, add = TRUE)
+        self$flags$is_printing <- TRUE
       }
 
       cat(crayon::silver("# Plumber router with ", endCount, " endpoint", ifelse(endCount == 1, "", "s"),", ",
@@ -953,6 +953,10 @@ Plumber <- R6Class(
       ret
     },
 
+    # list of key/value pairs that should be temporarily set. Ex: is_printing = 1
+    #' @field flags For internal use only
+    flags = list(),
+
 
     ### Legacy/Deprecated
     #' @description addEndpoint has been deprecated in v0.4.0 and will be removed in a coming release. Please use `handle()` instead.
@@ -1135,8 +1139,6 @@ Plumber <- R6Class(
     docs_info = NULL,
     docs_callback = NULL,
     debug = NULL,
-
-    flags = list(), # list of key/value pairs that should be temporarily set. Ex: printing = 1
 
     addFilterInternal = function(filter){
       # Create a new filter and add it to the router

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -30,7 +30,7 @@ defaultPlumberFilters <- list(
 
 #' Package Plumber Router
 #'
-#' Routers are the core request handler in plumber. A router is responsible for
+#' Routers are the core request handler in \pkg{plumber}. A router is responsible for
 #' taking an incoming request, submitting it through the appropriate filters and
 #' eventually to a corresponding endpoint, if one is found.
 #'
@@ -54,6 +54,7 @@ Plumber <- R6Class(
   "Plumber",
   inherit = Hookable,
   public = list(
+
     #' @description Create a new `Plumber` router
     #'
     #' See also [plumb()], [pr()]
@@ -131,7 +132,7 @@ Plumber <- R6Class(
       }
 
     },
-    #' @description Start a server using `plumber` object.
+    #' @description Start a server using `Plumber` object.
     #'
     #' See also: [pr_run()]
     #' @param host a string that is a valid IPv4 or IPv6 address that is owned by
@@ -179,7 +180,7 @@ Plumber <- R6Class(
             # $setDocs() has been called (other than during initialization).
             # Believe that it is the correct behavior
             # Warn about updating the run method
-            lifecycle::deprecate_warn("1.0.0", "run(swagger = )", details = "The plumber docs have already been set. Ignoring `swagger` parameter.")
+            lifecycle::deprecate_warn("1.0.0", "run(swagger = )", details = "The Plumber docs have already been set. Ignoring `swagger` parameter.")
           }
         }
       }
@@ -1020,23 +1021,23 @@ Plumber <- R6Class(
       self$getApiSpec()
     }
   ), active = list(
-    #' @field endpoints plumber router endpoints read-only
+    #' @field endpoints Plumber router endpoints read-only
     endpoints = function(){
       private$ends
     },
-    #' @field filters plumber router filters read-only
+    #' @field filters Plumber router filters read-only
     filters = function(){
       private$filts
     },
-    #' @field mounts plumber router mounts read-only
+    #' @field mounts Plumber router mounts read-only
     mounts = function(){
       private$mnts
     },
-    #' @field environment plumber router environment read-only
+    #' @field environment Plumber router environment read-only
     environment = function() {
       private$envir
     },
-    #' @field routes plumber router routes read-only
+    #' @field routes Plumber router routes read-only
     routes = function(){
       paths <- list()
 
@@ -1154,9 +1155,9 @@ Plumber <- R6Class(
       }
       if (!noPreempt && ! preempt %in% filterNames){
         if (!is.null(ep$lines)){
-          stopOnLine(ep$lines[1], private$fileLines[ep$lines[1]], paste0("The given @preempt filter does not exist in this plumber router: '", preempt, "'"))
+          stopOnLine(ep$lines[1], private$fileLines[ep$lines[1]], paste0("The given @preempt filter does not exist in this Plumber router: '", preempt, "'"))
         } else {
-          stop(paste0("The given preempt filter does not exist in this plumber router: '", preempt, "'"))
+          stop(paste0("The given preempt filter does not exist in this Plumber router: '", preempt, "'"))
         }
       }
 

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -1093,7 +1093,9 @@ Plumber <- R6Class(
 
       lexisort(paths)
     }
-  ), private = list(
+  ),
+  private = list(
+
     default_serializer = NULL, # The default serializer for the router
     default_parsers = NULL, # The default parsers for the router
 
@@ -1116,6 +1118,8 @@ Plumber <- R6Class(
     docs_info = NULL,
     docs_callback = NULL,
     debug = NULL,
+
+    flags = list(), # list of key/value pairs that should be temporarily set. Ex: printing = 1
 
     addFilterInternal = function(filter){
       # Create a new filter and add it to the router

--- a/man/Plumber.Rd
+++ b/man/Plumber.Rd
@@ -9,7 +9,7 @@ Package Plumber Router
 Package Plumber Router
 }
 \details{
-Routers are the core request handler in plumber. A router is responsible for
+Routers are the core request handler in \pkg{plumber}. A router is responsible for
 taking an incoming request, submitting it through the appropriate filters and
 eventually to a corresponding endpoint, if one is found.
 
@@ -116,18 +116,25 @@ pr$setErrorHandler(function(req, res, err) {
 \section{Super class}{
 \code{\link[plumber:Hookable]{plumber::Hookable}} -> \code{Plumber}
 }
+\section{Public fields}{
+\if{html}{\out{<div class="r6-fields">}}
+\describe{
+\item{\code{flags}}{For internal use only}
+}
+\if{html}{\out{</div>}}
+}
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{endpoints}}{plumber router endpoints read-only}
+\item{\code{endpoints}}{Plumber router endpoints read-only}
 
-\item{\code{filters}}{plumber router filters read-only}
+\item{\code{filters}}{Plumber router filters read-only}
 
-\item{\code{mounts}}{plumber router mounts read-only}
+\item{\code{mounts}}{Plumber router mounts read-only}
 
-\item{\code{environment}}{plumber router environment read-only}
+\item{\code{environment}}{Plumber router environment read-only}
 
-\item{\code{routes}}{plumber router routes read-only}
+\item{\code{routes}}{Plumber router routes read-only}
 }
 \if{html}{\out{</div>}}
 }
@@ -204,7 +211,7 @@ A new \code{Plumber} router
 \if{html}{\out{<a id="method-run"></a>}}
 \if{latex}{\out{\hypertarget{method-run}{}}}
 \subsection{Method \code{run()}}{
-Start a server using \code{plumber} object.
+Start a server using \code{Plumber} object.
 
 See also: \code{\link[=pr_run]{pr_run()}}
 \subsection{Usage}{

--- a/man/serializers.Rd
+++ b/man/serializers.Rd
@@ -130,7 +130,7 @@ more details on Plumber serializers and how to customize their behavior.
 
 \item \code{serializer_rds}: RDS serializer. See also: \code{\link[base:serialize]{base::serialize()}}
 
-\item \code{serializer_feather}: feather serializer. See also: \code{\link[feather:write_feather]{feather::write_feather()}}
+\item \code{serializer_feather}: feather serializer. See also: \code{\link[feather:read_feather]{feather::write_feather()}}
 
 \item \code{serializer_yaml}: YAML serializer. See also: \code{\link[yaml:as.yaml]{yaml::as.yaml()}}
 

--- a/tests/testthat/files/router-modifier-new.R
+++ b/tests/testthat/files/router-modifier-new.R
@@ -1,0 +1,5 @@
+#* @plumber
+function(ignore) {
+  # return new router
+  pr()
+}

--- a/tests/testthat/files/router-modifier.R
+++ b/tests/testthat/files/router-modifier.R
@@ -1,4 +1,4 @@
 #* @plumber
-function(pr){
+function(pr) {
   pr$handle("GET", "/avatartare", function(raw) {raw}, serializer = serializer_json)
 }

--- a/tests/testthat/test-plumber-print.R
+++ b/tests/testthat/test-plumber-print.R
@@ -106,8 +106,8 @@ test_that("prints recursion is detected", {
   printed2 <- capture.output(print(a))
   printed3 <- capture.output(print(b))
 
-  expect_match(printed, "Circular Plumber reference detected", all = FALSE)
-  expect_match(printed3, "Circular Plumber reference detected", all = FALSE)
+  expect_match(printed, "Circular Plumber router definition detected", all = FALSE)
+  expect_match(printed3, "Circular Plumber router definition detected", all = FALSE)
   expect_equal(printed, printed2)
 
 })

--- a/tests/testthat/test-plumber-print.R
+++ b/tests/testthat/test-plumber-print.R
@@ -93,3 +93,21 @@ test_that("prints correctly", {
 
   expect_equal(printed, expected_output)
 })
+
+
+test_that("prints recursion is detected", {
+  a <- pr()
+  b <- pr()
+
+  a$mount("B", b)
+  b$mount("A", a)
+
+  printed <- capture.output(print(a))
+  printed2 <- capture.output(print(a))
+  printed3 <- capture.output(print(b))
+
+  expect_match(printed, "Circular Plumber reference detected", all = FALSE)
+  expect_match(printed3, "Circular Plumber reference detected", all = FALSE)
+  expect_equal(printed, printed2)
+
+})

--- a/tests/testthat/test-router-modifier.R
+++ b/tests/testthat/test-router-modifier.R
@@ -1,10 +1,20 @@
 context("Router modifier (@plumber tag)")
 
-test_that("router modifier works, run does nothing", {
-  expect_error(
-    pr(test_path("files/router-modifier-run.R")),
-    "method should not be called while")
+test_that("router modifier works", {
   pr <- pr(test_path("files/router-modifier.R"))
   expect_equal(class(pr$routes[[1]])[1], "PlumberEndpoint")
   expect_equal(names(pr$routes), "avatartare")
+})
+
+test_that("$run() causes error", {
+  expect_error(
+    pr(test_path("files/router-modifier-run.R")),
+    "method should not be called while")
+})
+
+
+test_that("new routers can not be returned", {
+  expect_error(
+    pr(test_path("files/router-modifier-new.R")),
+    "not the same as the one provided")
 })

--- a/vignettes/annotations.Rmd
+++ b/vignettes/annotations.Rmd
@@ -11,11 +11,11 @@ vignette: >
 source("_helpers.R")
 ```
 
-## Annotations {#annotations} 
+## Annotations {#annotations}
 
 Annotations are specially-structured comments used in your plumber file to create an API. A full annotation line starts with `#*` or `#'`, then the annotation keyword `@...`, any number of space characters followed by the content. It is recommended to use `#*` to differentiate them from `Roxygen2` annotations.
 
-## Global annotations {#global-annotations} 
+## Global annotations {#global-annotations}
 
 Global annotations can be used anywhere in your plumber file. They are independent from other annotations and do not require an expression.
 
@@ -61,7 +61,7 @@ pr() %>%
   })
 ```
 
-## Block annotations {#block-annotations} 
+## Block annotations {#block-annotations}
 
 A block of annotations is a combination of annotations that create either an [endpoint](./routing-and-input.html#endpoints), a [filter](./routing-and-input.html#filters), a [static file handler](./routing-and-input.html#static-file-handler) or a Plumber object modifier. Block annotations are always followed by an expression.
 
@@ -120,8 +120,8 @@ function(f) {
 text_handler <- function(name, age) { sprintf("%s is %i years old", name, age) }
 file_handler <- function(file) { as_attachment(file[[1]], names(file)[1]) }
 pr() %>%
-  pr_get(path = "/dyn/<name:str>/<age:[int]>/route", 
-         handler = text_handler, 
+  pr_get(path = "/dyn/<name:str>/<age:[int]>/route",
+         handler = text_handler,
          serializer = serializer_text(),
          parsers = "none",
          responses = list("200" = list(description = "A sentence"))) %>%
@@ -194,11 +194,11 @@ pr() %>%
   pr_static("/", "./files/static")
 ```
 
-### Plumber Object Modifier {#plumber-block-annotations}
+### Plumber Router Modifier {#plumber-block-annotations}
 
 Annotation | Arguments | Description/References
 -----------| --------- | ----------------------
-`@plumber` | None | Modify plumber router from plumber file. 
+`@plumber` | None | Modify plumber router from plumber file. The plumber router provided to the function **must** be returned.
 
 ##### Annotations example
 


### PR DESCRIPTION
Fixes #592 
* Related: https://github.com/rstudio/plumber/pull/683
Fixes #707
* Related: https://github.com/rstudio/plumber/pull/710

Now throws an error:
```r
#* @plumber
function(pr) {
  pr() %>%
    pr_get()
}
```

Now does not print forever:
```r
a <- plumber$new()
b <- plumber$new()

a$mount("B", b)
b$mount("A", a)

print(a)
```

PR task list:
- [x] Update NEWS
- [x] Add tests
- [x] Update documentation with `devtools::document()`
