### PR TITLE
Do not return invisible(pr) for pr_*()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@ plumber 1.0.0.9999 Development version
 
 ### Bug fixes
 
+* Fixed bug where all `pr_*()` returned invisibly. Now all `pr_*()` methods will print the router if displayed in the console. (#740)
+
 * Ignore regular comments in block parsing (@meztez #718)
 
 * Block parsing comments, tags and responses ordering match plumber api ordering. (#722)

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -478,7 +478,7 @@ Plumber <- R6Class(
       }
       printNode(self$routes, "", prefix, TRUE)
 
-      invisible(self)
+      invisible(self) # actually needs to be invisible
     },
     #' @description Serve a request
     #' @param req request object
@@ -1120,7 +1120,8 @@ Plumber <- R6Class(
     addFilterInternal = function(filter){
       # Create a new filter and add it to the router
       private$filts <- c(private$filts, filter)
-      invisible(self)
+
+      self
     },
     addEndpointInternal = function(ep, preempt){
       noPreempt <- missing(preempt) || is.null(preempt)

--- a/R/pr.R
+++ b/R/pr.R
@@ -51,7 +51,7 @@ pr <- function(file = NULL,
 #' * `PUT`
 #' * `DELETE`
 #' * `HEAD`
-#' Each function mutates the Plumber router in place, but also invisibly returns
+#' Each function mutates the Plumber router in place and returns
 #' the updated router.
 #'
 #' @template param_pr
@@ -206,8 +206,8 @@ pr_head <- function(pr,
 #' Plumber routers can be “nested” by mounting one into another
 #' using the `mount()` method. This allows you to compartmentalize your API
 #' by paths which is a great technique for decomposing large APIs into smaller
-#' files. This function mutates the Plumber router ([pr()]) in place, but
-#' also invisibly returns the updated router.
+#' files. This function mutates the Plumber router ([pr()]) in place and
+#' returns the updated router.
 #'
 #' @param pr The host Plumber router.
 #' @param path A character string. Where to mount router.

--- a/R/pr.R
+++ b/R/pr.R
@@ -103,7 +103,7 @@ pr_handle <- function(pr,
             serializer = serializer,
             endpoint = endpoint,
             ...)
-  invisible(pr)
+  pr
 }
 
 #' @rdname pr_handle
@@ -232,7 +232,7 @@ pr_mount <- function(pr,
                      router) {
   validate_pr(pr)
   pr$mount(path = path, router = router)
-  invisible(pr)
+  pr
 }
 
 #' Register a hook
@@ -299,7 +299,7 @@ pr_hook <- function(pr,
                     handler) {
   validate_pr(pr)
   pr$registerHook(stage = stage, handler = handler)
-  invisible(pr)
+  pr
 }
 
 #' @rdname pr_hook
@@ -308,7 +308,7 @@ pr_hooks <- function(pr,
                      handlers) {
   validate_pr(pr)
   pr$registerHooks(handlers)
-  invisible(pr)
+  pr
 }
 
 #' Store session data in encrypted cookies.
@@ -425,7 +425,7 @@ pr_cookie <- function(pr,
   pr$registerHooks(
     session_cookie(key = key, name = name, expiration = expiration, http = http, secure = secure, same_site = same_site)
   )
-  invisible(pr)
+  pr
 }
 
 
@@ -460,7 +460,7 @@ pr_filter <- function(pr,
                       serializer) {
   validate_pr(pr)
   pr$filter(name = name, expr = expr, serializer = serializer)
-  invisible(pr)
+  pr
 }
 
 #' Start a server using `plumber` object

--- a/R/pr_set.R
+++ b/R/pr_set.R
@@ -12,7 +12,7 @@
 pr_set_serializer <- function(pr, serializer) {
   validate_pr(pr)
   pr$setSerializer(serializer)
-  invisible(pr)
+  pr
 }
 
 #' Set the default endpoint parsers for the router
@@ -32,7 +32,7 @@ pr_set_serializer <- function(pr, serializer) {
 pr_set_parsers <- function(pr, parsers) {
   validate_pr(pr)
   pr$setParsers(parsers)
-  invisible(pr)
+  pr
 }
 
 #' Set the handler that is called when the incoming request can't be served
@@ -62,7 +62,7 @@ pr_set_parsers <- function(pr, parsers) {
 pr_set_404 <- function(pr, fun) {
   validate_pr(pr)
   pr$set404Handler(fun)
-  invisible(pr)
+  pr
 }
 
 #' Set the error handler that is invoked if any filter or endpoint generates an
@@ -89,7 +89,7 @@ pr_set_404 <- function(pr, fun) {
 pr_set_error <- function(pr, fun) {
   validate_pr(pr)
   pr$setErrorHandler(fun)
-  invisible(pr)
+  pr
 }
 
 
@@ -121,7 +121,7 @@ pr_set_error <- function(pr, fun) {
 pr_set_debug <- function(pr, debug = interactive()) {
   validate_pr(pr)
   pr$setDebug(debug = debug)
-  invisible(pr)
+  pr
 }
 
 
@@ -184,7 +184,7 @@ pr_set_docs <- function(
 ) {
   validate_pr(pr)
   pr$setDocs(docs = docs, ...)
-  invisible(pr)
+  pr
 }
 
 
@@ -212,7 +212,7 @@ pr_set_docs_callback <- function(
 ) {
   validate_pr(pr)
   pr$setDocsCallback(callback = callback)
-  invisible(pr)
+  pr
 }
 
 
@@ -250,5 +250,5 @@ pr_set_api_spec <- function(
 ) {
   validate_pr(pr)
   pr$setApiSpec(api = api)
-  invisible(pr)
+  pr
 }

--- a/R/serializer.R
+++ b/R/serializer.R
@@ -447,7 +447,8 @@ self_set_serializer <- function(self, serializer) {
   } else {
     self$serializer <- serializer
   }
-  invisible(self)
+
+  self
 }
 
 

--- a/man/pr_handle.Rd
+++ b/man/pr_handle.Rd
@@ -53,7 +53,7 @@ functions are implemented for the following HTTP methods:
 \item \code{PUT}
 \item \code{DELETE}
 \item \code{HEAD}
-Each function mutates the Plumber router in place, but also invisibly returns
+Each function mutates the Plumber router in place and returns
 the updated router.
 }
 }

--- a/man/pr_mount.Rd
+++ b/man/pr_mount.Rd
@@ -20,8 +20,8 @@ A Plumber router with the supplied router mounted
 Plumber routers can be “nested” by mounting one into another
 using the \code{mount()} method. This allows you to compartmentalize your API
 by paths which is a great technique for decomposing large APIs into smaller
-files. This function mutates the Plumber router (\code{\link[=pr]{pr()}}) in place, but
-also invisibly returns the updated router.
+files. This function mutates the Plumber router (\code{\link[=pr]{pr()}}) in place and
+returns the updated router.
 }
 \examples{
 \dontrun{

--- a/man/serializers.Rd
+++ b/man/serializers.Rd
@@ -130,7 +130,7 @@ more details on Plumber serializers and how to customize their behavior.
 
 \item \code{serializer_rds}: RDS serializer. See also: \code{\link[base:serialize]{base::serialize()}}
 
-\item \code{serializer_feather}: feather serializer. See also: \code{\link[feather:write_feather]{feather::write_feather()}}
+\item \code{serializer_feather}: feather serializer. See also: \code{\link[feather:read_feather]{feather::write_feather()}}
 
 \item \code{serializer_yaml}: YAML serializer. See also: \code{\link[yaml:as.yaml]{yaml::as.yaml()}}
 


### PR DESCRIPTION
I had done some magrittr style work and did not immediately run the router.  When the commands finished, the router did not display... that was confusing.  Now it will display.

Without PR:
```r
> pr() %>% pr_get("/route", identity)
```

With PR:
```r
> pr() %>% pr_get("/route", identity)
# Plumber router with 1 endpoint, 4 filters, and 0 sub-routers.
# Call run() on this object to start the API.
├──[queryString]
├──[body]
├──[cookieParser]
├──[sharedSecret]
└──/route (GET)
```

PR task list:
- [x] Update NEWS
- [na] Add tests
- [x] Update documentation with `devtools::document()`
