### PR TITLE
Default res headers to named list instead of list

### DIFF
--- a/R/plumber-response.R
+++ b/R/plumber-response.R
@@ -7,7 +7,7 @@ PlumberResponse <- R6Class(
     },
     status = 200L,
     body = NULL,
-    headers = list(),
+    headers = stats::setNames(list(), character()),
     serializer = NULL,
     setHeader = function(name, value){
       he <- list()


### PR DESCRIPTION
In reference to #743 , and to avoid having to depends on httpuv 1.6

Or depends on httpuv 1.6?

PR task list:
- [ ] Update NEWS
- [ ] Add tests
- [ ] Update documentation with `devtools::document()`
