### PR TITLE
Default res headers to named list instead of list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@ plumber 1.0.0.9999 Development version
 
 ### Bug fixes
 
+* Fixed bug where `httpuv` would return a status of `500` with body `An exception occurred` if no headers were set on the response object. (#745)
+
 * Fixed bug where all `pr_*()` returned invisibly. Now all `pr_*()` methods will print the router if displayed in the console. (#740)
 
 * Ignore regular comments in block parsing (@meztez #718)

--- a/R/plumber-response.R
+++ b/R/plumber-response.R
@@ -7,7 +7,7 @@ PlumberResponse <- R6Class(
     },
     status = 200L,
     body = NULL,
-    headers = list(),
+    headers = stats::setNames(list(), character()),
     serializer = NULL,
     setHeader = function(name, value){
       he <- list()


### PR DESCRIPTION
Fixes #743

* Avoids having to depends on httpuv 1.6

PR task list:
- [x] Update NEWS
- [NA] Add tests
- [NA] Update documentation with `devtools::document()`
