### PR TITLE
Do not use `plan(multiprocess)`. Instead, use `plan(multisession)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@ plumber 1.0.0.9999 Development version
 
 * Plumber will now display a circular reference if one is found while printing. (#738)
 
+* Changed `future::plan()` from `multiprocess` to `multisession` in example API `14-future` as "Strategy 'multiprocess' is deprecated in future (>= 1.20.0)". (#747)
+
 
 plumber 1.0.0
 --------------------------------------------------------------------------------

--- a/inst/plumber/14-future/plumber.R
+++ b/inst/plumber/14-future/plumber.R
@@ -2,8 +2,8 @@
 library(promises)
 library(future)
 
-future::plan("multiprocess") # use all available cores
-# future::plan(future::multiprocess(workers = 2)) # only two cores
+future::plan("multisession") # a worker for each core
+# future::plan(future::multisession(workers = 2)) # only two workers
 
 # Quick manual test:
 # Within 10 seconds...

--- a/inst/plumber/14-future/test-future.R
+++ b/inst/plumber/14-future/test-future.R
@@ -69,7 +69,7 @@ cat(readLines(log_file), sep = "\n")
 }))
 # --------------------------
 
-## Sample output using future::plan(future::multiprocess(workers = 2)) # only two cores
+## Sample output using future::plan(future::multisession(workers = 2)) # only two workers
 # --START route requests
 # "/sync; 2019-10-07 13:11:06; pid:82424" - 1
 # "/sync; 2019-10-07 13:11:07; pid:82424" - 3
@@ -88,7 +88,7 @@ cat(readLines(log_file), sep = "\n")
 
 # --------------------------
 
-## Sample output using future::plan("multiprocess") # use all available cores
+## Sample output using future::plan("multisession") # a worker for each core
 # --START route requests
 # "/sync; 2019-10-07 13:16:22; pid:82424" - 1
 # "/sync; 2019-10-07 13:16:23; pid:82424" - 3


### PR DESCRIPTION
```r
future::plan(future::multiprocess)
#> Warning message:
#> Strategy 'multiprocess' is deprecated in future (>= 1.20.0). Instead, explicitly specify either 'multisession' or 'multicore'. In the current R session, 'multiprocess' equals 'multicore'.
```

PR task list:
- [x] Update NEWS
- [na] Add tests
- [na] Update documentation with `devtools::document()`
