### PR TITLE
When processing a route, use most specific mount paths first

### DIFF
--- a/R/default-handlers.R
+++ b/R/default-handlers.R
@@ -54,9 +54,10 @@ allowed_verbs <- function(pr, path_to_find) {
   }
 
   # look at all possible mounts
-  for (i in seq_along(pr$mounts)) {
-    mount <- pr$mounts[[i]]
-    mount_path <- sub("/$", "", names(pr$mounts)[i]) # trim trailing `/`
+  mnts <- pr$mounts
+  for (i in seq_along(mnts)) {
+    mount <- mnts[[i]]
+    mount_path <- sub("/$", "", names(mnts)[i]) # trim trailing `/`
 
     # if the front of the urls don't match, move on to next mount
     if (!identical(

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -1041,9 +1041,10 @@ Plumber <- R6Class(
     filters = function(){
       private$filts
     },
-    #' @field mounts Plumber router mounts read-only
+    #' @field mounts Plumber router mounts sorted by mount location. Read-only.
     mounts = function(){
-      private$mnts
+      mnts <- private$mnts
+      mnts[sort(names(mnts), decreasing = FALSE)]
     },
     #' @field environment Plumber router environment read-only
     environment = function() {

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -242,7 +242,9 @@ Plumber <- R6Class(
         path <- paste0(path, "/")
       }
 
+      # order the mounts so that the more specific mount paths are ahead of the less specific mount paths
       private$mnts[[path]] <- router
+      private$mnts <- private$mnts[order(names(private$mnts), decreasing = TRUE)]
     },
     #' @description Unmount a Plumber router
     #' @param path a character string. Where to unmount router.

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -412,7 +412,7 @@ Plumber <- R6Class(
 
       cat(crayon::silver("# Plumber router with ", endCount, " endpoint", ifelse(endCount == 1, "", "s"),", ",
                          as.character(length(private$filts)), " filter", ifelse(length(private$filts) == 1, "", "s"),", and ",
-                         as.character(length(self$mounts)), " sub-router", ifelse(length(self$mounts) == 1, "", "s"),".\n", sep=""))
+                         as.character(length(private$mnts)), " sub-router", ifelse(length(private$mnts) == 1, "", "s"),".\n", sep=""))
 
       if(topLevel){
         cat(prefix, crayon::silver("# Use `pr_run()` on this object to start the API.\n"), sep="")
@@ -947,7 +947,7 @@ Plumber <- R6Class(
       private$api_spec_handler <- api_fun
     },
     #' @description Retrieve openAPI file
-    getApiSpec = function() { #FIXME: test
+    getApiSpec = function() {
 
       routerSpec <- private$routerSpecificationInternal(self)
 
@@ -1033,11 +1033,11 @@ Plumber <- R6Class(
       self$getApiSpec()
     }
   ), active = list(
-    #' @field endpoints Plumber router endpoints read-only
+    #' @field endpoints Plumber router endpoints. Read-only
     endpoints = function(){
       private$ends
     },
-    #' @field filters Plumber router filters read-only
+    #' @field filters Plumber router filters. Read-only
     filters = function(){
       private$filts
     },
@@ -1046,11 +1046,11 @@ Plumber <- R6Class(
       mnts <- private$mnts
       mnts[sort(names(mnts), decreasing = FALSE)]
     },
-    #' @field environment Plumber router environment read-only
+    #' @field environment Plumber router environment. Read-only
     environment = function() {
       private$envir
     },
-    #' @field routes Plumber router routes read-only
+    #' @field routes Plumber router routes. Read-only
     routes = function(){
       paths <- list()
 
@@ -1104,14 +1104,15 @@ Plumber <- R6Class(
       })
 
       # Sub-routers
-      if (length(self$mounts) > 0){
-        for(i in 1:length(self$mounts)){
+      mnts <- self$mounts
+      if (length(mnts) > 0){
+        for(i in 1:length(mnts)){
           # Trim leading slash
-          path <- sub("^/", "", names(self$mounts)[i])
+          path <- sub("^/", "", names(mnts)[i])
 
           levels <- strsplit(path, "/", fixed=TRUE)[[1]]
 
-          m <- self$mounts[[i]]
+          m <- mnts[[i]]
           paths <- addPath(paths, levels, m)
         }
       }
@@ -1224,10 +1225,11 @@ Plumber <- R6Class(
       }
 
       # recursively gather mounted enpoint entries
-      if (length(router$mounts) > 0) {
-        for (mountPath in names(router$mounts)) {
+      router_mnts <- router$mounts
+      if (length(router_mnts) > 0) {
+        for (mountPath in sort(names(router_mnts))) {
           mountEndpoints <- private$routerSpecificationInternal(
-            router$mounts[[mountPath]],
+            router_mnts[[mountPath]],
             join_paths(parentPath, mountPath)
           )
           endpointList <- utils::modifyList(endpointList, mountEndpoints)

--- a/man/Plumber.Rd
+++ b/man/Plumber.Rd
@@ -126,15 +126,15 @@ pr$setErrorHandler(function(req, res, err) {
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{endpoints}}{Plumber router endpoints read-only}
+\item{\code{endpoints}}{Plumber router endpoints. Read-only}
 
-\item{\code{filters}}{Plumber router filters read-only}
+\item{\code{filters}}{Plumber router filters. Read-only}
 
-\item{\code{mounts}}{Plumber router mounts read-only}
+\item{\code{mounts}}{Plumber router mounts sorted by mount location. Read-only.}
 
-\item{\code{environment}}{Plumber router environment read-only}
+\item{\code{environment}}{Plumber router environment. Read-only}
 
-\item{\code{routes}}{Plumber router routes read-only}
+\item{\code{routes}}{Plumber router routes. Read-only}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Fixes https://github.com/rstudio/plumber/issues/734

* More specific mount paths will be found by using this order


Reprex:
```r
pr <- pr() %>% 
  pr_mount("/aaa", pr()) %>%
  pr_mount("/aaa/bbb",
           pr() %>% 
             pr_get("/hello", function() "hi")
  ) %>% pr_run()
```
... Which mount processes `/aaa/bbb/hello`?
* Before pr: `/aaa`
* With pr: `/aaa/bbb`


PR task list:
- [ ] Update NEWS
- [x] Add tests
- [x] Update documentation with `devtools::document()`

Questions:
* Is it ok to return different order for `pr$mounts`? (Now it is alpha sorted. Before, it was added order)