### PR TITLE
Setting `plumber.docs.callback` to `NULL` will also set legacy `plumber.swagger.url`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@ plumber 1.0.0.9999 Development version
 
 * Changed `future::plan()` from `multiprocess` to `multisession` in example API `14-future` as "Strategy 'multiprocess' is deprecated in future (>= 1.20.0)". (#747)
 
+* Setting options `plumber.docs.callback` to `NULL` will also set deprecated but supported option `plumber.swagger.url`. (#766)
 
 plumber 1.0.0
 --------------------------------------------------------------------------------

--- a/R/options_plumber.R
+++ b/R/options_plumber.R
@@ -67,6 +67,7 @@ options_plumber <- function(
 ) {
   ellipsis::check_dots_empty()
 
+  # Make sure all fallback options are disabled
   if (!missing(docs.callback) && is.null(docs.callback)) {
     options("plumber.swagger.url" = NULL)
   }

--- a/R/options_plumber.R
+++ b/R/options_plumber.R
@@ -67,6 +67,10 @@ options_plumber <- function(
 ) {
   ellipsis::check_dots_empty()
 
+  if (!missing(docs.callback) && is.null(docs.callback)) {
+    options("plumber.swagger.url" = NULL)
+  }
+
   options(
     plumber.port                 =   port,
     plumber.docs                 =   docs,

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -94,7 +94,7 @@ Plumber <- R6Class(
       self$set404Handler(default404Handler)
       self$setDocs(TRUE)
       private$docs_info$has_not_been_set <- TRUE # set to know if `$setDocs()` has been called before `$run()`
-      self$setDocsCallback(getOption('plumber.docs.callback', getOption('plumber.swagger.url', NULL)))
+      self$setDocsCallback(getOption('plumber.docs.callback', getOption('plumber.swagger.url')))
       self$setDebug(interactive())
       self$setApiSpec(NULL)
 

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -62,3 +62,12 @@ test_that("Legacy swagger redirect can be disabled", {
     expect_equal(length(redirects), 0)
   })
 })
+
+test_that("docs.callback sync plumber.swagger.url", {
+  with_options(list(), {
+    options("plumber.swagger.url" = function(api_url) {cat(api_url)})
+    opt <- options_plumber(docs.callback = NULL)
+    expect_null(getOption("plumber.swagger.url"))
+    expect_null(opt$plumber.docs.callback)
+  })
+})


### PR DESCRIPTION
…cated but supported option `plumber.swagger.url`.

Currently this does nothing since the router default to `plumber.swagger.url` when `plumber.docs.callback` is NULL

```r
library(plumber)
options_plumber(docs.callback = NULL)
pr() %>% pr_run()
```

This PR will make sure  `plumber.swagger.url` is set to `NULL` when calling `options_plumber(docs.callback = NULL)`.

We could also stop supporting `plumber.swagger.url` at some point.

PR task list:
- [x] Update NEWS
- [x] Add tests
- [ ] Update documentation with `devtools::document()`
