### PR TITLE
Add `PlumberEndpoint$setPath(path)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@ plumber 1.0.0.9999 Development version
 
 * OpenAPI Specification can be set using a file path. (@meztez #696)
 
+* Update internal regex if `PlumberEndpoint$path` is altered after initialization. (@blairj09 #770)
+
 ### Bug fixes
 
 * Fixed bug where `httpuv` would return a status of `500` with body `An exception occurred` if no headers were set on the response object. (#745)

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,7 @@ plumber 1.0.0.9999 Development version
 
 * OpenAPI Specification can be set using a file path. (@meztez #696)
 
-* Update internal regex if `PlumberEndpoint$path` is altered after initialization. (@blairj09 #770)
+* To update a `PlumberEndpoint` path after initialization, call the new `PlumberEndpoint$setPath(path)`. This will update internal path matching meta data. (Active bindings were not used to avoid breaking changes.) (@blairj09 #770)
 
 ### Bug fixes
 

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -277,6 +277,8 @@ PlumberEndpoint <- R6Class(
     }
   ),
   active = list(
+    # Normally, this would have been a `$setPath(path)` method, but `path` was already publicly available.
+    # It would not make sense to have `$getPath()` and deprecate `$path`
     #' @field path a character string. endpoint path
     path = function(value) {
       if (missing(value)) {

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -285,6 +285,7 @@ PlumberEndpoint <- R6Class(
       if (substr(value, 1,1) != "/") {
         value <- paste0("/", value)
       }
+      # private$func is not updated after initialization
       private$regex <- createPathRegex(value, self$getFuncParams())
       private$pathVal <- value
     }

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -171,6 +171,8 @@ PlumberEndpoint <- R6Class(
     #' to accept multiple verbs for a single path. Now it's simpler to just parse
     #' each separate verb/path into its own endpoint, so we just do that.
     verbs = NA,
+    #' @field path a character string. endpoint path
+    path = NA,
     #' @field comments endpoint comments
     comments = NA,
     #' @field responses endpoint responses
@@ -228,7 +230,7 @@ PlumberEndpoint <- R6Class(
       throw_if_func_is_not_a_function(private$func)
       private$envir <- envir
 
-      self$path <- path
+      self$setPath(path)
 
       if (!missing(serializer) && !is.null(serializer)){
         self_set_serializer(self, serializer)
@@ -274,27 +276,22 @@ PlumberEndpoint <- R6Class(
         return(list())
       }
       self$params
-    }
-  ),
-  active = list(
-    # Normally, this would have been a `$setPath(path)` method, but `path` was already publicly available.
+    },
     # It would not make sense to have `$getPath()` and deprecate `$path`
-    #' @field path a character string. endpoint path
-    path = function(value) {
-      if (missing(value)) {
-        return(private$pathVal)
-      }
-      if (substr(value, 1,1) != "/") {
-        value <- paste0("/", value)
+    #' @description Updates `$path` with a sanitized `path` and updates the internal path meta-data
+    #' @param path Path to set `$path`. If missing a beginning slash, one will be added.
+    setPath = function(path) {
+      if (substr(path, 1,1) != "/") {
+        path <- paste0("/", path)
       }
       # private$func is not updated after initialization
-      private$regex <- createPathRegex(value, self$getFuncParams())
-      private$pathVal <- value
+      self$path <- path
+      private$regex <- createPathRegex(path, self$getFuncParams())
+      path
     }
   ),
   private = list(
-    regex = NULL,
-    pathVal = NA
+    regex = NULL
   )
 )
 

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -171,8 +171,6 @@ PlumberEndpoint <- R6Class(
     #' to accept multiple verbs for a single path. Now it's simpler to just parse
     #' each separate verb/path into its own endpoint, so we just do that.
     verbs = NA,
-    #' @field path a character string. endpoint path
-    path = NA,
     #' @field comments endpoint comments
     comments = NA,
     #' @field responses endpoint responses
@@ -219,12 +217,7 @@ PlumberEndpoint <- R6Class(
     #' @return A new `PlumberEndpoint` object
     initialize = function(verbs, path, expr, envir, serializer, parsers, lines, params, comments, responses, tags) {
 
-      if (substr(path, 1,1) != "/") {
-        path <- paste0("/", path)
-      }
-
       self$verbs <- verbs
-      self$path <- path
 
       private$expr <- expr
       if (is.expression(expr)){
@@ -235,7 +228,7 @@ PlumberEndpoint <- R6Class(
       throw_if_func_is_not_a_function(private$func)
       private$envir <- envir
 
-      private$regex <- createPathRegex(path, self$getFuncParams())
+      self$path <- path
 
       if (!missing(serializer) && !is.null(serializer)){
         self_set_serializer(self, serializer)
@@ -283,8 +276,22 @@ PlumberEndpoint <- R6Class(
       self$params
     }
   ),
+  active = list(
+    #' @field path a character string. endpoint path
+    path = function(value) {
+      if (missing(value)) {
+        return(private$pathVal)
+      }
+      if (substr(value, 1,1) != "/") {
+        value <- paste0("/", value)
+      }
+      private$regex <- createPathRegex(value, self$getFuncParams())
+      private$pathVal <- value
+    }
+  ),
   private = list(
-    regex = NULL
+    regex = NULL,
+    pathVal = NA
   )
 )
 

--- a/man/PlumberEndpoint.Rd
+++ b/man/PlumberEndpoint.Rd
@@ -24,8 +24,6 @@ They can also be provided manually for historical reasons.
 to accept multiple verbs for a single path. Now it's simpler to just parse
 each separate verb/path into its own endpoint, so we just do that.}
 
-\item{\code{path}}{a character string. endpoint path}
-
 \item{\code{comments}}{endpoint comments}
 
 \item{\code{responses}}{endpoint responses}
@@ -35,6 +33,13 @@ each separate verb/path into its own endpoint, so we just do that.}
 \item{\code{tags}}{endpoint tags}
 
 \item{\code{parsers}}{step allowed parsers}
+}
+\if{html}{\out{</div>}}
+}
+\section{Active bindings}{
+\if{html}{\out{<div class="r6-active-bindings">}}
+\describe{
+\item{\code{path}}{a character string. endpoint path}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/PlumberEndpoint.Rd
+++ b/man/PlumberEndpoint.Rd
@@ -24,6 +24,8 @@ They can also be provided manually for historical reasons.
 to accept multiple verbs for a single path. Now it's simpler to just parse
 each separate verb/path into its own endpoint, so we just do that.}
 
+\item{\code{path}}{a character string. endpoint path}
+
 \item{\code{comments}}{endpoint comments}
 
 \item{\code{responses}}{endpoint responses}
@@ -33,13 +35,6 @@ each separate verb/path into its own endpoint, so we just do that.}
 \item{\code{tags}}{endpoint tags}
 
 \item{\code{parsers}}{step allowed parsers}
-}
-\if{html}{\out{</div>}}
-}
-\section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
-\item{\code{path}}{a character string. endpoint path}
 }
 \if{html}{\out{</div>}}
 }
@@ -53,6 +48,7 @@ each separate verb/path into its own endpoint, so we just do that.}
 \item \href{#method-getPathParams}{\code{PlumberEndpoint$getPathParams()}}
 \item \href{#method-getFuncParams}{\code{PlumberEndpoint$getFuncParams()}}
 \item \href{#method-getEndpointParams}{\code{PlumberEndpoint$getEndpointParams()}}
+\item \href{#method-setPath}{\code{PlumberEndpoint$setPath()}}
 \item \href{#method-clone}{\code{PlumberEndpoint$clone()}}
 }
 }
@@ -221,6 +217,23 @@ retrieve endpoint defined parameters
 \if{html}{\out{<div class="r">}}\preformatted{PlumberEndpoint$getEndpointParams()}\if{html}{\out{</div>}}
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-setPath"></a>}}
+\if{latex}{\out{\hypertarget{method-setPath}{}}}
+\subsection{Method \code{setPath()}}{
+Updates \verb{$path} with a sanitized \code{path} and updates the internal path meta-data
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PlumberEndpoint$setPath(path)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{path}}{Path to set \verb{$path}. If missing a beginning slash, one will be added.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}

--- a/tests/testthat/test-endpoint.R
+++ b/tests/testthat/test-endpoint.R
@@ -114,3 +114,20 @@ test_that("Programmatic endpoints with functions work", {
   h <- res$headers
   expect_true(h$expr)
 })
+
+test_that("Path rewrites correctly", {
+  foo_pr <- pr() %>%
+    pr_get("/foo", function() "foo")
+
+  foo <- foo_pr$endpoints[[1]][[1]]
+
+  expect_true("foo" %in% names(foo_pr$routes))
+  expect_true(foo$matchesPath("/foo"))
+  expect_false(foo$matchesPath("/bar"))
+
+  foo$path <- "bar"
+
+  expect_false("foo" %in% names(foo_pr$routes))
+  expect_false(foo$matchesPath("/foo"))
+  expect_true(foo$matchesPath("/bar"))
+})

--- a/tests/testthat/test-endpoint.R
+++ b/tests/testthat/test-endpoint.R
@@ -125,7 +125,7 @@ test_that("Path rewrites correctly", {
   expect_true(foo$matchesPath("/foo"))
   expect_false(foo$matchesPath("/bar"))
 
-  foo$path <- "bar"
+  foo$setPath("bar")
 
   expect_false("foo" %in% names(foo_pr$routes))
   expect_false(foo$matchesPath("/foo"))


### PR DESCRIPTION
Allows the user to easily rewrite endpoint paths without needing to invoke private methods.