### PR TITLE
Shared secret rejections are not errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 * OpenAPI response type detection had a scoping issue. Use serializer defined `Content-Type` header instead. (@meztez, #789)
 
+* The default shared secret filter returns error responses without throwing an error. (#808)
+
 # plumber 1.1.0
 
 ## Breaking changes

--- a/R/shared-secret-filter.R
+++ b/R/shared-secret-filter.R
@@ -7,7 +7,14 @@ sharedSecretFilter <- function(req, res){
       res$status <- 400
       # Force the route to return as unboxed json
       res$serializer <- serializer_unboxed_json()
-      return(list(error = "Shared secret mismatch."))
+      # Using output similar to `defaultErrorHandler()`
+      li <- list(error = "400 - Bad request")
+      
+      # Don't overly leak data unless they opt-in
+      if (is.function(req$pr$getDebug) && isTRUE(req$pr$getDebug())) {
+        li$message <- "Shared secret mismatch"
+      }
+      return(li)
     }
   }
 

--- a/R/shared-secret-filter.R
+++ b/R/shared-secret-filter.R
@@ -5,7 +5,7 @@ sharedSecretFilter <- function(req, res){
     supplied <- req$HTTP_PLUMBER_SHARED_SECRET
     if (!identical(supplied, secret)){
       res$status <- 400
-      stop("The provided shared secret did not match expected secret.")
+      return(list(error = "Shared secret mismatch."))
     }
   }
 

--- a/R/shared-secret-filter.R
+++ b/R/shared-secret-filter.R
@@ -5,6 +5,8 @@ sharedSecretFilter <- function(req, res){
     supplied <- req$HTTP_PLUMBER_SHARED_SECRET
     if (!identical(supplied, secret)){
       res$status <- 400
+      # Force the route to return as unboxed json
+      res$serializer <- serializer_unboxed_json()
       return(list(error = "Shared secret mismatch."))
     }
   }

--- a/tests/testthat/test-shared-secret.R
+++ b/tests/testthat/test-shared-secret.R
@@ -9,8 +9,9 @@ test_that("requests with shared secrets pass, w/o fail", {
   # No shared secret
   req <- make_req("GET", "/")
   res <- PlumberResponse$new()
-  capture.output(pr$route(req, res))
+  output <- pr$route(req, res)
   expect_equal(res$status, 400)
+  expect_equal(output, list(error = "Shared secret mismatch."))
 
   # Set shared secret
   assign("HTTP_PLUMBER_SHARED_SECRET", "abcdefg", envir=req)

--- a/tests/testthat/test-shared-secret.R
+++ b/tests/testthat/test-shared-secret.R
@@ -5,13 +5,23 @@ test_that("requests with shared secrets pass, w/o fail", {
 
   pr <- pr()
   pr$handle("GET", "/", function(){ 123 })
+  req <- make_req("GET", "/", pr = pr)
 
   # No shared secret
-  req <- make_req("GET", "/")
   res <- PlumberResponse$new()
   output <- pr$route(req, res)
   expect_equal(res$status, 400)
-  expect_equal(output, list(error = "Shared secret mismatch."))
+  expect_equal(output, list(error = "400 - Bad request"))
+
+  # When debugging, we get additional details in the error.
+  pr$setDebug(TRUE)
+  res <- PlumberResponse$new()
+  output <- pr$route(req, res)
+  expect_equal(res$status, 400)
+  expect_equal(output, list(
+    error = "400 - Bad request",
+    message = "Shared secret mismatch"))
+  pr$setDebug(FALSE)
 
   # Set shared secret
   assign("HTTP_PLUMBER_SHARED_SECRET", "abcdefg", envir=req)


### PR DESCRIPTION
This change has the shared secret filter no longer log an error and returns a cleaner error response.

```r
options(`plumber.sharedSecret`="abcdefg")
p <- plumber::Plumber$new(file = NULL)
p$run()
# Running plumber API at http://127.0.0.1:8050
# Running swagger Docs at http://127.0.0.1:8050/__docs__/
```

```console
curl http://127.0.0.1:8050/
# {"error": "Shared secret mismatch."}
```

Fixes #808 

CC @blairj09 