### PR TITLE
Add details about named functions as router modifiers

### DIFF
--- a/vignettes/annotations.Rmd
+++ b/vignettes/annotations.Rmd
@@ -217,7 +217,7 @@ pr() %>%
 
 Annotation | Arguments | Description/References
 -----------| --------- | ----------------------
-`@plumber` | None | Modify plumber router from plumber file. The plumber router provided to the function **must** be returned.
+`@plumber` | None | Modify plumber router from plumber file. The plumber router provided to the function **must** be returned. In most cases, anonymous functions are used following the `#* @plumber` annotation. However, named functions can also be used. When a named function is used, it must be referenced without parentheses.
 
 ##### Annotations example
 
@@ -228,6 +228,16 @@ function(pr) {
     pr_set_debug(TRUE) %>%
     pr_set_docs("swagger")
 }
+
+# Named function
+debug_swagger <- function(pr) {
+  pr %>%
+    pr_set_debug(TRUE) %>%
+    pr_set_docs("swagger")
+}
+
+#* @plumber
+debug_swagger
 ```
 
 ##### Equivalent programmatic usage


### PR DESCRIPTION
With the introduction of [`plumbertableau`](https://github.com/rstudio/plumbertableau), some users have expressed confusion about the following syntax:
```r
#* @plumber
tableau_extension
```

Where `tableau_extension` is a defined router modifier exported from the `plumbertableau` package. The confusion comes from the fact that `tableau_extension` does not _look_ like a function since there are now following parentheses. This PR attempts to clarify this use case in the Plumber documentation.