### PR TITLE
Test on ubuntu 18/20 and use relative R versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,9 +1,16 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow is overkill for most R packages and
+# check-standard.yaml is likely a better choice.
 on:
   push:
     branches:
+      - main
       - master
   pull_request:
     branches:
+      - main
       - master
   schedule:
     - cron:  '0 0 1,11,21 * *' # every 10 days (GHA cache invalidates after 7)
@@ -11,6 +18,25 @@ on:
 name: R-CMD-check
 
 jobs:
+
+  rversions:
+    name: R Versions
+    runs-on: ubuntu-latest
+    outputs:
+      devel:   ${{ steps.devel.outputs.installed-r-version }}
+      release: ${{ steps.release.outputs.installed-r-version }}
+      oldrel1: ${{ steps.oldrel1.outputs.installed-r-version }}
+      oldrel2: ${{ steps.oldrel2.outputs.installed-r-version }}
+      oldrel3: ${{ steps.oldrel3.outputs.installed-r-version }}
+      oldrel4: ${{ steps.oldrel4.outputs.installed-r-version }}
+    steps:
+    - { name: devel,    uses: r-lib/actions/setup-r@master, id: devel,   with: { r-version: devel,    install-r: false }}
+    - { name: release,  uses: r-lib/actions/setup-r@master, id: release, with: { r-version: release,  install-r: false }}
+    - { name: oldrel/1, uses: r-lib/actions/setup-r@master, id: oldrel1, with: { r-version: oldrel/1, install-r: false }}
+    - { name: oldrel/2, uses: r-lib/actions/setup-r@master, id: oldrel2, with: { r-version: oldrel/2, install-r: false }}
+    - { name: oldrel/3, uses: r-lib/actions/setup-r@master, id: oldrel3, with: { r-version: oldrel/3, install-r: false }}
+    - { name: oldrel/4, uses: r-lib/actions/setup-r@master, id: oldrel4, with: { r-version: oldrel/4, install-r: false }}
+
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
@@ -20,30 +46,26 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel'}
-          - {os: macOS-latest,   r: 'release'}
-          - {os: macOS-latest,   r: 'oldrel'}
+          - {os: macOS-latest,   r: '${{ needs.rversions.outputs.release }}'}
+          - {os: windows-latest, r: '${{ needs.rversions.outputs.release }}'}
+          - {os: windows-latest, r: '3.6'}
 
-          - {os: windows-latest, r: 'devel'}
-          - {os: windows-latest, r: 'release'}
-          # - {os: windows-latest, r: 'oldrel'} # do not test due to binaries not being created
+          - {os: ubuntu-20.04,   r: '${{ needs.rversions.outputs.devel }}', http-user-agent: "release" }
+          - {os: ubuntu-20.04,   r: '${{ needs.rversions.outputs.release }}'}
+          - {os: ubuntu-20.04,   r: '${{ needs.rversions.outputs.oldrel1 }}'}
+          - {os: ubuntu-20.04,   r: '${{ needs.rversions.outputs.oldrel2 }}'}
+          - {os: ubuntu-20.04,   r: '${{ needs.rversions.outputs.oldrel3 }}'}
+          - {os: ubuntu-20.04,   r: '${{ needs.rversions.outputs.oldrel4 }}'}
 
-          # check a lot of ubuntu combinations as that's where plumber is hosted
-          - {os: ubuntu-18.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   r: '3.4',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-
-          # would use RSPM for ubuntu 16, but sodium has issues finding libsodium
-          - {os: ubuntu-16.04,   r: 'release'}
-          - {os: ubuntu-16.04,   r: 'oldrel'}
-          - {os: ubuntu-16.04,   r: '3.5'}
-          - {os: ubuntu-16.04,   r: '3.4'}
+          # Deliberately check on older ubuntu to maximise backward compatibility
+          - {os: ubuntu-18.04,   r: '${{ needs.rversions.outputs.devel }}', http-user-agent: "release" }
+          - {os: ubuntu-18.04,   r: '${{ needs.rversions.outputs.release }}'}
+          - {os: ubuntu-18.04,   r: '${{ needs.rversions.outputs.oldrel1 }}'}
+          - {os: ubuntu-18.04,   r: '${{ needs.rversions.outputs.oldrel2 }}'}
+          - {os: ubuntu-18.04,   r: '${{ needs.rversions.outputs.oldrel3 }}'}
+          - {os: ubuntu-18.04,   r: '${{ needs.rversions.outputs.oldrel4 }}'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      _R_CHECK_FORCE_SUGGESTS_: false
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -54,30 +76,19 @@ jobs:
         with:
           node-version: '12.x'
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
         id: install-r
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v1
 
-      - name: Install pak and query dependencies
-        shell: Rscript {0}
-        run: |
-          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-          saveRDS(pak::pkg_deps_tree("local::.", dependencies = TRUE), ".github/r-depends.rds")
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-2-${{ hashFiles('.github/r-depends.rds') }}
-          restore-keys: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-2-
-
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        shell: Rscript {0}
-        run: |
-          pak::local_system_requirements(execute = TRUE)
+          extra-packages: rcmdcheck
+          cache-version: 1
 
       # Install Cairo system dependencies
       # used for svg testing
@@ -87,40 +98,12 @@ jobs:
           brew install --cask xquartz
           brew install cairo
 
-      - name: macOS oldrel Rcpp
-        if: runner.os == 'macOS' && matrix.config.r == 'oldrel'
-        shell: Rscript {0}
-        run: |
-          install.packages("Rcpp", type = "source")
-      - name: Ubuntu 16 xml2
-        if: matrix.config.os == 'ubuntu-16.04'
-        shell: Rscript {0}
-        run: |
-          pak::pkg_system_requirements("withr", execute = TRUE)
-          pak::pkg_install("withr")
-          pak::pkg_system_requirements("xml2", execute = TRUE)
-          # https://github.com/r-lib/xml2/issues/294
-          # always install for now
-          withr::with_makevars(c(CXX = "g++ -std=c++11"), install.packages("xml2", verbose = TRUE))
-
-      - name: Install dependencies
-        shell: Rscript {0}
-        run: |
-          pak::local_install_dev_deps(upgrade = TRUE)
-          pak::pkg_install("rcmdcheck")
-          pak::pkg_install("sessioninfo")
-
-      - name: Session info
-        run: |
-          options(width = 100)
-          pkgs <- installed.packages()[, "Package"]
-          sessioninfo::session_info(pkgs, include_base = TRUE)
-        shell: Rscript {0}
-
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        run: |
+          options(crayon.enabled = TRUE)
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 
       - name: Show testthat output
@@ -130,7 +113,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@main
         with:
           name: ${{ matrix.config.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,6 +42,8 @@ jobs:
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
+    needs:
+      - rversions
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Ubuntu 16 was removed. Update the GHA to the latest `r-lib/actions` / `shinyverse` style 

PR task list:
- [NA] Update NEWS
- [NA] Add tests
- [NA] Update documentation with `devtools::document()`
