### PR TITLE
Tweak Dockerfile; Reduce final size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 ARG R_VERSION=latest
 
 FROM rocker/r-ver:${R_VERSION}
-LABEL maintainer="barret@rstudio.com"
 LABEL org.opencontainers.image.authors="barret@rstudio.com"
 
 # BEGIN rstudio/plumber layers

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM rocker/r-ver:${R_VERSION}
 LABEL org.opencontainers.image.authors="barret@rstudio.com"
 
 # BEGIN rstudio/plumber layers
+
+# `rm` call removes `apt` cache
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
   git-core \
   libssl-dev \
@@ -14,6 +16,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
   libxml2-dev \
   && rm -rf /var/lib/apt/lists/*
 
+# `rm` call removes install2.r's cache
 RUN install2.r --error --skipinstalled --ncpus -1 \
   remotes \
   && rm -rf /tmp/downloaded_packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG R_VERSION=latest
 
 FROM rocker/r-ver:${R_VERSION}
 LABEL maintainer="barret@rstudio.com"
+LABEL org.opencontainers.image.authors="barret@rstudio.com"
 
 # BEGIN rstudio/plumber layers
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
@@ -11,9 +12,12 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
   libcurl4-gnutls-dev \
   curl \
   libsodium-dev \
-  libxml2-dev
+  libxml2-dev \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN install2.r remotes
+RUN install2.r --error --skipinstalled --ncpus -1 \
+  remotes \
+  && rm -rf /tmp/downloaded_packages
 
 ## Remove this comment to always bust the Docker cache at this step
 ## https://stackoverflow.com/a/55621942/591574

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ https://www.rplumber.io/articles/hosting.html#rstudio-connect-1.
 A couple of other approaches to hosting plumber are also made available:
 
  - PM2 - https://www.rplumber.io/articles/hosting.html#pm2-1
- - Docker - https://www.rplumber.io/articles/hosting.html#docker-basic-
+ - Docker - https://www.rplumber.io/articles/hosting.html#docker
+
 ## Related Projects
 
 - [OpenCPU](https://www.opencpu.org/) - A server designed for hosting R APIs

--- a/vignettes/hosting.Rmd
+++ b/vignettes/hosting.Rmd
@@ -106,7 +106,7 @@ So your custom Dockerfile could be as simple as:
 
 ```
 FROM rstudio/plumber
-MAINTAINER Docker User <docker@user.org>
+LABEL org.opencontainers.image.authors="Docker User <docker@user.org>"
 
 RUN R -e "install.packages('broom')"
 
@@ -138,7 +138,6 @@ We'll use Docker Compose to help us organize multiple Plumber processes. We won'
 You should define a Docker Compose configuration that defines the behavior of every Plumber application that you want to run. You'll first want to setup a Dockerfile that defines the desired behavior for each of your applications (as [we outlined previously](#custom-dockerfiles). You could use a `docker-compose.yml` configuration like the following:
 
 ```yaml
-version: '2'
 services:
   app1:
     build: ./app1/


### PR DESCRIPTION
- Use the `org.opencontainers.image.authors` annotation instead of the `maintainer` label. (See <https://docs.docker.com/engine/reference/builder/#maintainer-deprecated>)
- Remove temp files to reduce image size. (c.f. Dockerfile best practices <https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run>)
  - `apt`'s cache `/var/lib/apt/lists/*`
  - `install2.r`'s cache `/tmp/downloaded_packages`
- Fix docs link