### PR TITLE
Mount docs as first mount

### DIFF
--- a/R/plumber.R
+++ b/R/plumber.R
@@ -269,6 +269,8 @@ Plumber <- R6Class(
           quiet = quiet
         )
         # Unmount the docs before restoring the wd
+        # Unmount needs to happen after exit hooks
+        # No guarantee that new exit hooks are not added after running API
         on.exit(unmount_docs(self, docs_info), add = TRUE)
       }
 

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -250,9 +250,9 @@ Plumber <- R6Class(
       }
 
       # Set and restore the wd to make it appear that the proc is running local to the file's definition.
+      old_wd <- NULL
       if (!is.null(private$filename)) {
         old_wd <- setwd(dirname(private$filename))
-        on.exit({setwd(old_wd)}, add = TRUE)
       }
 
       if (isTRUE(docs_info$enabled)) {
@@ -266,9 +266,11 @@ Plumber <- R6Class(
           quiet = quiet
         )
         on.exit(unmount_docs(self, docs_info), add = TRUE)
+        on.exit({
+        }, add = TRUE)
       }
 
-      on.exit(private$runHooks("exit"), add = TRUE)
+      # Restore the prior working directory after exit hooks have run
 
       httpuv::runServer(host, port, self)
     },

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -258,6 +258,7 @@ Plumber <- R6Class(
       if (isTRUE(docs_info$enabled)) {
         mount_docs(
           pr = self,
+          pr_private = private,
           host = host,
           port = port,
           docs_info = docs_info,

--- a/man/Plumber.Rd
+++ b/man/Plumber.Rd
@@ -114,7 +114,7 @@ pr$setErrorHandler(function(req, res, err) {
 \code{\link[=pr_set_docs_callback]{pr_set_docs_callback()}}
 }
 \section{Super class}{
-\code{\link[plumber:Hookable]{plumber::Hookable}} -> \code{Plumber}
+\code{plumber::Hookable} -> \code{Plumber}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/PlumberEndpoint.Rd
+++ b/man/PlumberEndpoint.Rd
@@ -15,7 +15,7 @@ Parameters values are obtained from parsing blocks of lines in a plumber file.
 They can also be provided manually for historical reasons.
 }
 \section{Super classes}{
-\code{\link[plumber:Hookable]{plumber::Hookable}} -> \code{\link[plumber:PlumberStep]{plumber::PlumberStep}} -> \code{PlumberEndpoint}
+\code{plumber::Hookable} -> \code{plumber::PlumberStep} -> \code{PlumberEndpoint}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/PlumberStatic.Rd
+++ b/man/PlumberStatic.Rd
@@ -12,7 +12,7 @@ Static file router
 Creates a router that is backed by a directory of files on disk.
 }
 \section{Super classes}{
-\code{\link[plumber:Hookable]{plumber::Hookable}} -> \code{\link[plumber:Plumber]{plumber::Plumber}} -> \code{PlumberStatic}
+\code{plumber::Hookable} -> \code{plumber::Plumber} -> \code{PlumberStatic}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/man/PlumberStep.Rd
+++ b/man/PlumberStep.Rd
@@ -8,7 +8,7 @@ an object representing a step in the lifecycle of the treatment
 of a request by a plumber router.
 }
 \section{Super class}{
-\code{\link[plumber:Hookable]{plumber::Hookable}} -> \code{PlumberStep}
+\code{plumber::Hookable} -> \code{PlumberStep}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/man/deprecated_r6.Rd
+++ b/man/deprecated_r6.Rd
@@ -22,7 +22,7 @@ Deprecated R6 functions
 }}
 \keyword{internal}
 \section{Super class}{
-\code{\link[plumber:Hookable]{plumber::Hookable}} -> \code{hookable}
+\code{plumber::Hookable} -> \code{hookable}
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -68,7 +68,7 @@ The objects of this class are cloneable with this method.
 }
 }
 \section{Super classes}{
-\code{\link[plumber:Hookable]{plumber::Hookable}} -> \code{\link[plumber:Plumber]{plumber::Plumber}} -> \code{plumber}
+\code{plumber::Hookable} -> \code{plumber::Plumber} -> \code{plumber}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/tests/testthat/helper-interrupt.R
+++ b/tests/testthat/helper-interrupt.R
@@ -1,0 +1,6 @@
+
+with_interrupt <- function(expr, delay = 0) {
+  # Causes pr_run() to immediately exit
+  later::later(httpuv::interrupt, delay = delay)
+  force(expr)
+}

--- a/tests/testthat/test-plumber-run.R
+++ b/tests/testthat/test-plumber-run.R
@@ -1,10 +1,4 @@
 
-with_interrupt <- function(expr) {
-  # Causes pr_run() to immediately exit
-  later::later(httpuv::interrupt)
-  force(expr)
-}
-
 test_that("quiet=TRUE suppresses startup messages", {
   with_interrupt({
     expect_message(pr() %>% pr_run(quiet = TRUE), NA)

--- a/tests/testthat/test-ui.R
+++ b/tests/testthat/test-ui.R
@@ -1,0 +1,26 @@
+
+test_that("doc mounts are prepended", {
+
+  assertions <- 0
+
+  root <-
+    test_path("files/static.R") %>%
+    pr() %>%
+    pr_set_docs(TRUE) %>%
+    pr_hook("exit", function(...) {
+      expect_length(root$mounts, 3)
+      assertions <<- assertions + 1
+      expect_equal(names(root$mounts)[1], "/__docs__/")
+      assertions <<- assertions + 1
+    })
+
+  expect_length(root$mounts, 2)
+  assertions <- assertions + 1
+
+  # no docs. do not find printed message
+  with_interrupt({
+    root %>% pr_run()
+  })
+
+  expect_equal(assertions, 3)
+})


### PR DESCRIPTION
Fixes #881 

Other changes:
* working directory is restored last, not before the `exit` hooks are run.

PR task list:
- [ ] Update NEWS
- [x] Add tests
- [x] Update documentation with `devtools::document()`

cc @aronatkins 