### PR TITLE
Mounted router fall back to parent router when route is not found

### DIFF
--- a/R/plumber-static.R
+++ b/R/plumber-static.R
@@ -62,9 +62,10 @@ PlumberStatic <- R6Class(
         path <- httpuv::decodeURIComponent(path)
         abs.path <- resolve_path(direc, path)
         if (is.null(abs.path)) {
-          # TODO: Should this be inherited from a parent router?
-          val <- private$notFoundHandler(req=req, res=res)
-          return(val)
+          # If the file doesn't exist and isn't mounted,
+          # the 404 handler will be called anyways.
+          # So, we can always `forward()` here when the file isn't found.
+          return(forward())
         }
 
         ext <- tools::file_ext(abs.path)

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -20,6 +20,14 @@ resetForward <- function() {
   exec$forward <- FALSE
 }
 
+# Handle mounted routes not being found
+routeNotFound <- function() {
+  structure(list(), class = "plumber_route_not_found")
+}
+isRouteNotFound <- function(x) {
+  inherits(x, "plumber_route_not_found")
+}
+
 #' plumber step R6 class
 #' @description an object representing a step in the lifecycle of the treatment
 #' of a request by a plumber router.

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -768,12 +768,31 @@ Plumber <- R6Class(
           resetForward()
           # TODO: support globbing?
 
-          if (nchar(path) >= nchar(mountPath) && substr(path, 0, nchar(mountPath)) == mountPath) {
-            # This is a prefix match or exact match. Let this router handle.
+          # Keep track of how many mount levels deep we are.
+          # Can not use a boolean as a nested mount will unwrap before the parent mount is done.
+          # Using a counter allows us to know when we are at the top level router (0).
+          if (is.null(req$`_MOUNT_COUNT`)) {
+            req$`_MOUNT_COUNT` <- 0
+          }
 
+          if (nchar(path) >= nchar(mountPath) && substr(path, 0, nchar(mountPath)) == mountPath) {
+            # This is a prefix match or exact match. Let mount attempt handle.
+
+            # Mark that the route is within a mount. Allows for the mount to forward instead of 404.
+            req$`_MOUNT_COUNT` <- req$`_MOUNT_COUNT` + 1
             # First trim the prefix off of the PATH_INFO element
+            curPathInfo <- req$PATH_INFO
             req$PATH_INFO <- substr(req$PATH_INFO, nchar(mountPath), nchar(req$PATH_INFO))
-            return(private$mnts[[mountPath]]$route(req, res))
+            ret <- private$mnts[[mountPath]]$route(req, res)
+            # Undo path info changes and mark that we are no longer mounted
+            req$PATH_INFO <- curPathInfo
+            req$`_MOUNT_COUNT` <- req$`_MOUNT_COUNT` - 1
+            if (isRouteNotFound(ret)) {
+              # Forward to the parent router if mounted router can't handle
+              return(forward())
+            }
+            # Return the regular value from the mounted router
+            return(ret)
           } else {
             return(forward())
           }
@@ -825,7 +844,15 @@ Plumber <- R6Class(
         }
 
         # Notify that there is no route found
-        private$notFoundHandler(req = req, res = res)
+        mount_count <- req$`_MOUNT_COUNT`
+        if (!is.null(mount_count) && mount_count > 0) {
+          # If this is a mounted router, we need to forward to the parent router
+          # This value is used above when retrieving values from a mount
+          # Do not change this value without updating the recursive mount code above
+          return(routeNotFound())
+        } else {
+          private$notFoundHandler(req = req, res = res)
+        }
       }
       steps <- append(steps, list(notFoundStep))
 

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -767,14 +767,6 @@ Plumber <- R6Class(
         function(...) {
           resetForward()
           # TODO: support globbing?
-
-          # Keep track of how many mount levels deep we are.
-          # Can not use a boolean as a nested mount will unwrap before the parent mount is done.
-          # Using a counter allows us to know when we are at the top level router (0).
-          if (is.null(req$`_MOUNT_COUNT`)) {
-            req$`_MOUNT_COUNT` <- 0
-          }
-
           if (nchar(path) >= nchar(mountPath) && substr(path, 0, nchar(mountPath)) == mountPath) {
             # This is a prefix match or exact match. Let mount attempt handle.
 

--- a/tests/testthat/files/router.R
+++ b/tests/testthat/files/router.R
@@ -61,3 +61,17 @@ function(res){
 function(){
   "dual path"
 }
+
+#* @plumber
+function(pr) {
+  mnt_1 <-
+    pr() %>%
+    pr_get("/hello", function() "say hello")
+  mnt_2 <-
+    pr() %>%
+    pr_get("/world", function() "say hello world")
+
+  pr %>%
+    pr_mount("/say", mnt_1) %>%
+    pr_mount("/say/hello", mnt_2)
+}

--- a/tests/testthat/test-routing.R
+++ b/tests/testthat/test-routing.R
@@ -20,6 +20,12 @@ test_that("Routing to errors and 404s works", {
   expect_equal(r$route(make_req("GET", "/path1"), res), "dual path")
   expect_equal(r$route(make_req("GET", "/path2"), res), "dual path")
 
+  ## Mounts fall back to parent router when route is not found
+  # Mount at `/say` with route `/hello`
+  expect_equal(r$route(make_req("GET", "/say/hello"), res), "say hello")
+  # Mount at `/say/hello` with route `/world`
+  expect_equal(r$route(make_req("GET", "/say/hello/world"), res), "say hello world")
+
   expect_equal(errors, 0)
   expect_equal(notFounds, 0)
 


### PR DESCRIPTION
A different solution to #881 

Situation:
* Static handler is mounted at `/`;
* Route `/b/z` is mounted at `/a`
* Route `/c` is mounted at `/a/b`

Goal: Request `/a/b/c`

Current behavior: 
* The route of `/a/b/c` matches against mount location of `/`.
* The static file handler attempts to handle `/a/b/c`. 
	* No file is found, a 404 is returned.

New behavior: 
* The route of `/a/b/c` matches against mount location of `/`.
* The static file handler attempts to handle `/a/b/c`
	* No file is found, route is forwarded
	* Mount's `$route()` is marked as `routeNotFound()`
* The route of `/a/b/c` matches against mount location `/a`
	* The route is trimmed to `/b/c`
	* The route `/b/c` does not match any routes
	* Mount's `$route()` is marked as `routeNotFound()`
* The route of `/a/b/c` matches against mount location `/a/b`
	* The route is trimmed to `/c`
	* The route `/c` matches route location `/c`
	* Result of `/c` is returned

This would allow for #882 to not be merged, keep the docs as the last mount location. This benefits the user in that their content will always have preference over anything mounted in `/__docs__/`

PR task list:
- [ ] Should this behavior be opt in? Opt out?
- [ ] How should the user opt in / out? 
	* `$set_fallback(fallback = TRUE)`?
	* `$mount(path, router, fallback = TRUE)`?
- [ ] Update NEWS
- [x] Add tests
- [ ] Update documentation with `devtools::document()`