### PR TITLE
make fastmap dependency explicit

### DIFF
--- a/inst/plumber/14-future/plumber.R
+++ b/inst/plumber/14-future/plumber.R
@@ -1,6 +1,7 @@
 
 library(promises)
 library(coro)
+library(fastmap)
 future::plan("multisession") # a worker for each core
 # future::plan(future::multisession(workers = 2)) # only two workers
 


### PR DESCRIPTION
`fastmap` must be available to call `promises::future_promises()`; since it is only a `Suggests`ed dependency, renv / packrat will not identify it as necessary, causing runtime failures.

```r
r$> renv::dependencies("inst/plumber/14-future/plumber.R")
Finding R package dependencies ... Done!
                                                                               Source  Package Require Version   Dev
1 /Users/edavidaja/Documents/rstudiopbc/open/plumber/inst/plumber/14-future/plumber.R     coro                 FALSE
2 /Users/edavidaja/Documents/rstudiopbc/open/plumber/inst/plumber/14-future/plumber.R   future                 FALSE
3 /Users/edavidaja/Documents/rstudiopbc/open/plumber/inst/plumber/14-future/plumber.R promises                 FALSE
```

PR task list:
- [ ] Update NEWS
- [ ] Add tests
- [ ] Update documentation with `devtools::document()`
