### PR TITLE
Draft changes to support Dates and DateTime

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,8 @@ Suggests:
     geojsonsf,
     redoc,
     rapidoc,
-    sf
+    sf,
+    lubridate
 RoxygenNote: 7.2.2
 Collate:
     'async.R'

--- a/R/openapi-spec.R
+++ b/R/openapi-spec.R
@@ -147,12 +147,13 @@ parametersSpecification <- function(endpointParams, pathParams, funcParams = NUL
       )
       if (type %in% inRaw) {
         names(params$requestBody$content) <- "multipart/form-data"
-        property$type <- apiTypesInfo[[type]]$realType
+        property$type <- apiTypesInfo[[type]]$openApiType
+        property$format <- apiTypesInfo[[type]]$openApiFormat
         property$example <- NULL
       }
       if (isArray) {
         property$items <- list(
-          type = apiTypesInfo[[type]]$realType,
+          type = apiTypesInfo[[type]]$openApiType,
           format = property$format,
           example = property$example
         )
@@ -170,8 +171,8 @@ parametersSpecification <- function(endpointParams, pathParams, funcParams = NUL
         `in` = location,
         required = required,
         schema = list(
-          type = apiTypesInfo[[type]]$realType,
-          format = apiTypesInfo[[type]]$format,
+          type = apiTypesInfo[[type]]$openApiType,
+          format = apiTypesInfo[[type]]$openApiFormat,
           default = funcParams[[p]]$default
         )
       )
@@ -179,8 +180,8 @@ parametersSpecification <- function(endpointParams, pathParams, funcParams = NUL
         paramList$schema <- list(
           type = "array",
           items = list(
-            type = apiTypesInfo[[type]]$realType,
-            format = apiTypesInfo[[type]]$format
+            type = apiTypesInfo[[type]]$openApiType,
+            format = apiTypesInfo[[type]]$openApiFormat
           ),
           default = funcParams[[p]]$default
         )

--- a/R/openapi-spec.R
+++ b/R/openapi-spec.R
@@ -152,7 +152,7 @@ parametersSpecification <- function(endpointParams, pathParams, funcParams = NUL
       }
       if (isArray) {
         property$items <- list(
-          type = property$type,
+          type = apiTypesInfo[[type]]$realType,
           format = property$format,
           example = property$example
         )
@@ -170,7 +170,7 @@ parametersSpecification <- function(endpointParams, pathParams, funcParams = NUL
         `in` = location,
         required = required,
         schema = list(
-          type = type,
+          type = apiTypesInfo[[type]]$realType,
           format = apiTypesInfo[[type]]$format,
           default = funcParams[[p]]$default
         )
@@ -179,7 +179,7 @@ parametersSpecification <- function(endpointParams, pathParams, funcParams = NUL
         paramList$schema <- list(
           type = "array",
           items = list(
-            type = type,
+            type = apiTypesInfo[[type]]$realType,
             format = apiTypesInfo[[type]]$format
           ),
           default = funcParams[[p]]$default

--- a/R/openapi-types.R
+++ b/R/openapi-types.R
@@ -18,7 +18,7 @@ add_api_info_onLoad <- function() {
         converter = converter,
         format = format,
         location = location,
-        realType = ifelse(is.null(realType), apiType, realType),
+        realType = apiType %||% realType,
         # Q: Do we need to safe guard against special characters, such as `,`?
         # https://github.com/rstudio/plumber/pull/532#discussion_r439584727
         # A: https://swagger.io/docs/specification/serialization/

--- a/R/openapi-types.R
+++ b/R/openapi-types.R
@@ -18,7 +18,7 @@ add_api_info_onLoad <- function() {
         converter = converter,
         format = format,
         location = location,
-        realType = realType,
+        realType = ifelse(is.null(realType), apiType, realType),
         # Q: Do we need to safe guard against special characters, such as `,`?
         # https://github.com/rstudio/plumber/pull/532#discussion_r439584727
         # A: https://swagger.io/docs/specification/serialization/
@@ -69,6 +69,24 @@ add_api_info_onLoad <- function() {
     "[^/]+",
     as.character,
     location = c("query", "path")
+  )
+  addApiInfo(
+    "date-time",
+    c("POSIXct", "POSIXt"),
+    "[^/]+",
+    lubridate::as_datetime,
+    format = "date-time",
+    location = c("query", "path"),
+    realType = "string"
+  )
+  addApiInfo(
+    "date",
+    c("Date"),
+    "[^/]+",
+    lubridate::as_date,
+    format = "date",
+    location = c("query", "path"),
+    realType = "string"
   )
   addApiInfo(
     "object",

--- a/R/parse-query.R
+++ b/R/parse-query.R
@@ -81,7 +81,7 @@ createPathRegex <- function(pathDef, funcParams = NULL){
   plumberTypes <- stri_replace_all(match[,3], "$1", regex = "^\\[([^\\]]*)\\]$")
   if (length(funcParams) > 0) {
     # Override with detection of function args if type not found in map
-    idx <- !(plumberTypes %in% names(plumberToApiTypeMap))
+    idx <- !(plumberTypes %in% names(apiTypesInfo))
     plumberTypes[idx] <- sapply(funcParams, `[[`, "type")[names[idx]]
   }
   apiTypes <- plumberToApiType(plumberTypes, inPath = TRUE)
@@ -130,7 +130,7 @@ typesToParsers <- function(apiTypes, areArrays = FALSE) {
   mapply(
     function(x, y) {x[[y]]},
     apiTypesInfo[apiTypes],
-    ifelse(areArrays, "openApiParserArray", "openApiParser"),
+    ifelse(areArrays, "parserArray", "parser"),
     USE.NAMES = FALSE
   )
 }

--- a/R/parse-query.R
+++ b/R/parse-query.R
@@ -72,7 +72,7 @@ createPathRegex <- function(pathDef, funcParams = NULL){
         names = character(),
         types = NULL,
         regex = paste0("^", pathDef, "$"),
-        converters = NULL,
+        parsers = NULL,
         areArrays = NULL
       )
     )
@@ -108,7 +108,7 @@ createPathRegex <- function(pathDef, funcParams = NULL){
     names = names,
     types = apiTypes,
     regex = paste0("^", pathRegex, "$"),
-    converters = typesToConverters(apiTypes, areArrays),
+    parsers = typesToParsers(apiTypes, areArrays),
     areArrays = areArrays
   )
 }
@@ -119,18 +119,18 @@ typesToRegexps <- function(apiTypes, areArrays = FALSE) {
   mapply(
     function(x, y) {x[[y]]},
     apiTypesInfo[apiTypes],
-    ifelse(areArrays, "regexArray", "regex"),
+    ifelse(areArrays, "openApiRegexArray", "openApiRegex"),
     USE.NAMES = FALSE
   )
 }
 
 
-typesToConverters <- function(apiTypes, areArrays = FALSE) {
+typesToParsers <- function(apiTypes, areArrays = FALSE) {
   # return list of functions
   mapply(
     function(x, y) {x[[y]]},
     apiTypesInfo[apiTypes],
-    ifelse(areArrays, "converterArray", "converter"),
+    ifelse(areArrays, "openApiParserArray", "openApiParser"),
     USE.NAMES = FALSE
   )
 }
@@ -142,10 +142,10 @@ extractPathParams <- function(def, path){
   vals <- as.list(stri_match(path, regex = def$regex)[,-1])
   names(vals) <- def$names
 
-  if (!is.null(def$converters)){
-    # Run each value through its converter
+  if (!is.null(def$parsers)){
+    # Run each value through its parser
     for (i in 1:length(vals)){
-      vals[[i]] <- def$converters[[i]](vals[[i]])
+      vals[[i]] <- def$parsers[[i]](vals[[i]])
     }
   }
 

--- a/tests/testthat/files/path-params.R
+++ b/tests/testthat/files/path-params.R
@@ -32,3 +32,13 @@ function(req){
 function(id, price){
   list(id=id, price=price)
 }
+
+#* @get /yearend/<when:date>
+function(req){
+  req$args$when
+}
+
+#* @get /closing/<when:datetime>
+function(req){
+  req$args$when
+}

--- a/tests/testthat/test-path-subst.R
+++ b/tests/testthat/test-path-subst.R
@@ -63,7 +63,7 @@ test_that("variables are typed", {
   expect_equal(p$names, "id")
   expect_equal(p$regex, paste0("^/car/", "((?:(?:[^/]+),?)+)", "$"))
   expect_equal(p$areArrays, TRUE)
-  expect_equal(p$converters[[1]]("BOB,LUKE,GUY"), c("BOB", "LUKE", "GUY"))
+  expect_equal(p$parsers[[1]]("BOB,LUKE,GUY"), c("BOB", "LUKE", "GUY"))
 
   #Check that warnings happen on typo or unsupported type
   expect_warning(createPathRegex("/car/<id:motor>"),

--- a/tests/testthat/test-path-subst.R
+++ b/tests/testthat/test-path-subst.R
@@ -56,6 +56,14 @@ test_that("variables are typed", {
   expect_equal(p$names, "id")
   expect_equal(p$regex, paste0("^/car/", "((?:(?:[01tfTF]|true|false|TRUE|FALSE),?)+)", "$"))
 
+  p <- createPathRegex("/price/<when:date>")
+  expect_equal(p$names, "when")
+  expect_equal(p$regex, paste0("^/price/", "(\\d{4}-\\d{2}-\\d{2})", "$"))
+
+  p <- createPathRegex("/price/<before:datetime>")
+  expect_equal(p$names, "before")
+  expect_equal(p$regex, paste0("^/price/", "(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)", "$"))
+
   p <- createPathRegex("/car/<id:chr>")
   expect_equal(p$names, "id")
   expect_equal(p$regex, paste0("^/car/", "([^/]+)", "$"))
@@ -102,6 +110,10 @@ test_that("integration of path parsing works", {
   expect_equal(r$route(make_req("GET", "/car/ratio/-1.5"), PlumberResponse$new()), -1.5)
   expect_equal(r$route(make_req("GET", "/car/ratio/-.5"), PlumberResponse$new()), -.5)
   expect_equal(r$route(make_req("GET", "/car/ratio/.5"), PlumberResponse$new()), .5)
+
+  expect_equal(r$route(make_req("GET", "/yearend/2022-12-31"), PlumberResponse$new()), lubridate::as_date("2022-12-31"))
+  expect_equal(r$route(make_req("GET", "/closing/2022-12-24T18:30:00Z"), PlumberResponse$new()), lubridate::as_datetime("2022-12-24T18:30:00Z"))
+
   expect_equal(r$route(make_req("GET", "/car/ratio/a"), PlumberResponse$new()),
                list(error = "404 - Resource Not Found"))
   expect_equal(r$route(make_req("GET", "/car/ratio/"), PlumberResponse$new()),

--- a/tests/testthat/test-zzz-openapi.R
+++ b/tests/testthat/test-zzz-openapi.R
@@ -298,7 +298,7 @@ test_that("multiple variations in function extract correct metadata", {
                         var5 = defaultIsArray, var6 = TRUE,
                         var7 = defaultIsArray, var8 = defaultIsArray))
   expect_identical(lapply(funcParams, `[[`, "type"),
-                   list(var0 = "number", var1 = defaultApiType, var2 = "integer", var3 = defaultApiType, var4 = defaultApiType,
+                   list(var0 = "double", var1 = defaultApiType, var2 = "integer", var3 = defaultApiType, var4 = defaultApiType,
                         var5 = "boolean", var6 = "object", var7 = defaultApiType, var8 = defaultApiType))
 
 })

--- a/tests/testthat/test-zzz-openapi.R
+++ b/tests/testthat/test-zzz-openapi.R
@@ -4,7 +4,7 @@ test_that("plumberToApiType works", {
   expect_equal(plumberToApiType("bool"), "boolean")
   expect_equal(plumberToApiType("logical"), "boolean")
 
-  expect_equal(plumberToApiType("double"), "number")
+  expect_equal(plumberToApiType("double"), "double")
   expect_equal(plumberToApiType("numeric"), "number")
 
   expect_equal(plumberToApiType("int"), "integer")
@@ -145,7 +145,7 @@ test_that("parametersSpecification works", {
   ep <- list(id=list(desc="Description", type="integer", required=FALSE),
              id2=list(desc="Description2", required=FALSE), # No redundant type specification
              make=list(desc="Make description", type="string", required=FALSE),
-             prices=list(desc="Historic sell prices", type="numeric", required = FALSE, isArray = TRUE),
+             prices=list(desc="Historic sell prices", type="double", required = FALSE, isArray = TRUE),
              claims=list(desc="Insurance claims", type="object", required = FALSE))
   pp <- data.frame(name=c("id", "id2", "owners"), type=c("int", "int", "chr"), isArray = c(FALSE, FALSE, TRUE), stringsAsFactors = FALSE)
 

--- a/tests/testthat/test-zzz-openapi.R
+++ b/tests/testthat/test-zzz-openapi.R
@@ -281,7 +281,9 @@ test_that("multiple variations in function extract correct metadata", {
                     var5 = FALSE,
                     var6 = list(name = c("luke", "bob"), lastname = c("skywalker", "ross")),
                     var7 = new.env(parent = .GlobalEnv),
-                    var8 = list(a = 2, b = mean, c = new.env(parent = .GlobalEnv))) {}
+                    var8 = list(a = 2, b = mean, c = new.env(parent = .GlobalEnv)),
+                    var9 = lubridate::ymd("2022-12-03"),
+                    var10 = lubridate::ymd_hms("2022-12-03T10:11:12")) {}
   funcParams <- getArgsMetadata(dummy)
   expect_identical(sapply(funcParams, `[[`, "required"),
                    c(var0 = FALSE, var1 = TRUE, var2 = FALSE, var3 = FALSE, var4 = FALSE,


### PR DESCRIPTION
This is a PR for #890 - providing Date and DateTime support

## PR task list:

Functional:
- [x] Discuss design and make sure the maintainer is happy...
- [x] Discuss implementation and make sure the maintainer is happy...
- [x] I suspect the regexes "could be better"...

Admin:

- [x] Sign RStudio CLA 
- [ ] Update NEWS
- [ ] Update articles
- [ ] Add tests
  - [ ] GET and POST query parameters
  - [ ] body parameters
  - [ ] dynamic route parameters
  - [ ] parameters which don't parse
- [ ] Run `devtools::check()`
- [ ] Update documentation with `devtools::document()`

## Minimal reproducible example

Manual test files used so far:

```r

#* Consider this...
#* @param when:date the date
#* @param t:date-time The date and time
#* @get /dates
function(when, t) {

  browser()
  paste0("The date was ", when, " and the time was ", t)
}
```

That seems to work:
![image](https://user-images.githubusercontent.com/533662/204513456-4e23d2e7-1227-4d1e-9129-b21e848b3aa5.png)

Note: have also tested this alongside #889 