### PR TITLE
Dynamic Plot Endpoints

### DIFF
--- a/R/openapi-spec.R
+++ b/R/openapi-spec.R
@@ -17,8 +17,18 @@ endpointSpecification <- function(routerEndpointEntry, path = routerEndpointEntr
   funcParams <- routerEndpointEntry$getFuncParams()
   # Get the plumber decoration defined endpoint params
   endpointParams <- routerEndpointEntry$getEndpointParams()
+
+  # if legacy plumber.staticSerializers is specified then ignore all req serializer
+  # based parameters
+  if (getOption("plumber.staticSerializers", default="FALSE") == "TRUE") {
+    serializerParams <- list()
+  } else {
+    # Get the plumber serializer defined endpoint params
+    serializerParams <- routerEndpointEntry$getSerializerParams()
+  }
+
   for (verb in routerEndpointEntry$verbs) {
-    params <- parametersSpecification(endpointParams, pathParams, funcParams)
+    params <- parametersSpecification(endpointParams, pathParams, funcParams, serializerParams)
 
     # If we haven't already documented a path param, we should add it here.
     # FIXME: warning("Undocumented path parameters: ", paste0())
@@ -81,7 +91,7 @@ responsesSpecification <- function(endpts){
 #' Extract the OpenAPI parameters Specification from the endpoint
 #' paramters.
 #' @noRd
-parametersSpecification <- function(endpointParams, pathParams, funcParams = NULL){
+parametersSpecification <- function(endpointParams, pathParams, funcParams = NULL, serializerParams = NULL){
 
   params <- list(
     parameters = list(),
@@ -89,7 +99,7 @@ parametersSpecification <- function(endpointParams, pathParams, funcParams = NUL
   )
   inBody <- filterApiTypes("requestBody", "location")
   inRaw <- filterApiTypes("binary", "format")
-  for (p in unique(c(names(endpointParams), pathParams$name, names(funcParams)))) {
+  for (p in unique(c(names(endpointParams), pathParams$name, names(funcParams), names(serializerParams)))) {
 
     # Dealing with priorities endpointParams > pathParams > funcParams
     # For each p, find out which source to trust for :
@@ -112,26 +122,33 @@ parametersSpecification <- function(endpointParams, pathParams, funcParams = NUL
       type <- priorizeProperty(defaultApiType,
                                pathParams[pathParams$name == p,]$type,
                                endpointParams[[p]]$type,
-                               funcParams[[p]]$type)
+                               funcParams[[p]]$type,
+                               serializerParams[[p]]$type)
       type <- plumberToApiType(type, inPath = TRUE)
       isArray <- priorizeProperty(defaultIsArray,
                                   pathParams[pathParams$name == p,]$isArray,
                                   endpointParams[[p]]$isArray,
-                                  funcParams[[p]]$isArray)
+                                  funcParams[[p]]$isArray,
+                                  serializerParams[[p]]$isArray)
     } else {
       location <- "query"
       style <- "form"
       explode <- TRUE
       type <- priorizeProperty(defaultApiType,
                                endpointParams[[p]]$type,
-                               funcParams[[p]]$type)
+                               funcParams[[p]]$type,
+                               serializerParams[[p]]$type)
       type <- plumberToApiType(type)
       isArray <- priorizeProperty(defaultIsArray,
                                   endpointParams[[p]]$isArray,
-                                  funcParams[[p]]$isArray)
+                                  funcParams[[p]]$isArray,
+                                  serializerParams[[p]]$isArray)
       required <- priorizeProperty(funcParams[[p]]$required,
-                                   endpointParams[[p]]$required)
+                                   endpointParams[[p]]$required,
+                                   serializerParams[[p]]$required)
     }
+
+    desc <- endpointParams[[p]]$desc %||% serializerParams[[p]]$desc
 
     # Building OpenAPI Specification
     if (type %in% inBody) {
@@ -143,7 +160,7 @@ parametersSpecification <- function(endpointParams, pathParams, funcParams = NUL
         type = type,
         format = apiTypesInfo[[type]]$format,
         example = funcParams[[p]]$example,
-        description = endpointParams[[p]]$desc
+        description = desc
       )
       if (type %in% inRaw) {
         names(params$requestBody$content) <- "multipart/form-data"
@@ -166,7 +183,7 @@ parametersSpecification <- function(endpointParams, pathParams, funcParams = NUL
     } else {
       paramList <- list(
         name = p,
-        description = endpointParams[[p]]$desc,
+        description = desc,
         `in` = location,
         required = required,
         schema = list(

--- a/R/options_plumber.R
+++ b/R/options_plumber.R
@@ -41,6 +41,9 @@
 #' \item{`plumber.legacyRedirects`}{Plumber will redirect legacy route `/__swagger__/` and
 #' `/__swagger__/index.html` to `../__docs__/` and `../__docs__/index.html`. You can disable this
 #' by settings this option to `FALSE`. Defaults to `TRUE`}
+#' \item{`plumber.staticSerializers`}{Plumber will use fixed serializers and
+#' will not interpret e.g. plot_width and plot_height parameters as plot image
+#' size instructions}
 #' }
 #'
 #' @param ... Ignored. Should be empty
@@ -64,7 +67,8 @@ options_plumber <- function(
   apiPath              = getOption("plumber.apiPath"),
   maxRequestSize       = getOption("plumber.maxRequestSize"),
   sharedSecret         = getOption("plumber.sharedSecret"),
-  legacyRedirects      = getOption("plumber.legacyRedirects")
+  legacyRedirects      = getOption("plumber.legacyRedirects"),
+  staticSerializers    = getOption("plumber.staticSerializers")
 ) {
   ellipsis::check_dots_empty()
 
@@ -86,6 +90,7 @@ options_plumber <- function(
     plumber.apiPath              =   apiPath,
     plumber.maxRequestSize       =   maxRequestSize,
     plumber.sharedSecret         =   sharedSecret,
-    plumber.legacyRedirects      =   legacyRedirects
+    plumber.legacyRedirects      =   legacyRedirects,
+    plumber.staticSerializers    =   staticSerializers
   )
 }

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -196,6 +196,8 @@ PlumberEndpoint <- R6Class(
     },
     #' @field params endpoint parameters
     params = NA,
+    #' @field serializer_params serializer parameters
+    serializer_params = NULL,
     #' @field tags endpoint tags
     tags = NA,
     #' @field parsers step allowed parsers
@@ -295,6 +297,13 @@ PlumberEndpoint <- R6Class(
         return(list())
       }
       self$params
+    },
+    #' @description retrieve serializer endpoint parameters
+    getSerializerParams = function() {
+      if (is.null(self$serializer_params)) {
+        return(list())
+      }
+      return(self$serializer_params)
     },
     # It would not make sense to have `$getPath()` and deprecate `$path`
     #' @description Updates `$path` with a sanitized `path` and updates the internal path meta-data

--- a/R/serializer.R
+++ b/R/serializer.R
@@ -681,20 +681,24 @@ serializer_svg <- function(..., type = "image/svg+xml") {
     serializer_params = serializer_param_list(all_except = c("res"))
   )
 }
+
 #' @describeIn serializers BMP image serializer. See also: [grDevices::bmp()]
 #' @export
 serializer_bmp <- function(..., type = "image/bmp") {
   serializer_device(
     type = type,
-    dev_on = serializer_image_dev_on_func(grDevices::bmp, ...)
+    dev_on = serializer_image_dev_on_func(grDevices::bmp, ...),
+    serializer_params = serializer_param_list()
   )
 }
+
 #' @describeIn serializers TIFF image serializer. See also: [grDevices::tiff()]
 #' @export
 serializer_tiff <- function(..., type = "image/tiff") {
   serializer_device(
     type = type,
-    dev_on = serializer_image_dev_on_func(grDevices::tiff, ...)
+    dev_on = serializer_image_dev_on_func(grDevices::tiff, ...),
+    serializer_params = serializer_param_list()
   )
 }
 

--- a/man/PlumberEndpoint.Rd
+++ b/man/PlumberEndpoint.Rd
@@ -34,6 +34,8 @@ each separate verb/path into its own endpoint, so we just do that.}
 
 \item{\code{params}}{endpoint parameters}
 
+\item{\code{serializer_params}}{serializer parameters}
+
 \item{\code{tags}}{endpoint tags}
 
 \item{\code{parsers}}{step allowed parsers}
@@ -51,6 +53,7 @@ each separate verb/path into its own endpoint, so we just do that.}
 \item \href{#method-PlumberEndpoint-getFunc}{\code{PlumberEndpoint$getFunc()}}
 \item \href{#method-PlumberEndpoint-getFuncParams}{\code{PlumberEndpoint$getFuncParams()}}
 \item \href{#method-PlumberEndpoint-getEndpointParams}{\code{PlumberEndpoint$getEndpointParams()}}
+\item \href{#method-PlumberEndpoint-getSerializerParams}{\code{PlumberEndpoint$getSerializerParams()}}
 \item \href{#method-PlumberEndpoint-setPath}{\code{PlumberEndpoint$setPath()}}
 \item \href{#method-PlumberEndpoint-clone}{\code{PlumberEndpoint$clone()}}
 }
@@ -234,6 +237,16 @@ retrieve endpoint expression parameters
 retrieve endpoint defined parameters
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{PlumberEndpoint$getEndpointParams()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-PlumberEndpoint-getSerializerParams"></a>}}
+\if{latex}{\out{\hypertarget{method-PlumberEndpoint-getSerializerParams}{}}}
+\subsection{Method \code{getSerializerParams()}}{
+retrieve serializer endpoint parameters
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PlumberEndpoint$getSerializerParams()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/endpoint_serializer.Rd
+++ b/man/endpoint_serializer.Rd
@@ -8,7 +8,8 @@ endpoint_serializer(
   serializer,
   preexec_hook = NULL,
   postexec_hook = NULL,
-  aroundexec_hook = NULL
+  aroundexec_hook = NULL,
+  serializer_params = list()
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ endpoint_serializer(
 \item{postexec_hook}{Function to be run directly after a \link{PlumberEndpoint} calls its route method.}
 
 \item{aroundexec_hook}{Function to be run around a \link{PlumberEndpoint} call. Must handle a \code{.next} argument to continue execution. \lifecycle{experimental}}
+
+\item{serializer_params}{Dynamic serializer parameters. More docs needed here!}
 }
 \description{
 This method allows serializers to return \code{preexec}, \code{postexec}, and \code{aroundexec} (\lifecycle{experimental}) hooks in addition to a serializer.

--- a/man/options_plumber.Rd
+++ b/man/options_plumber.Rd
@@ -18,7 +18,8 @@ options_plumber(
   apiPath = getOption("plumber.apiPath"),
   maxRequestSize = getOption("plumber.maxRequestSize"),
   sharedSecret = getOption("plumber.sharedSecret"),
-  legacyRedirects = getOption("plumber.legacyRedirects")
+  legacyRedirects = getOption("plumber.legacyRedirects"),
+  staticSerializers = getOption("plumber.staticSerializers")
 )
 }
 \arguments{
@@ -74,5 +75,8 @@ When \code{NULL}, secret is not validated. Otherwise, Plumber compares secret wi
 \item{\code{plumber.legacyRedirects}}{Plumber will redirect legacy route \verb{/__swagger__/} and
 \verb{/__swagger__/index.html} to \verb{../__docs__/} and \verb{../__docs__/index.html}. You can disable this
 by settings this option to \code{FALSE}. Defaults to \code{TRUE}}
+\item{\code{plumber.staticSerializers}}{Plumber will use fixed serializers and
+will not interpret e.g. plot_width and plot_height parameters as plot image
+size instructions}
 }
 }

--- a/man/serializers.Rd
+++ b/man/serializers.Rd
@@ -71,7 +71,12 @@ serializer_write_file(type, write_fn, fileext = NULL)
 
 serializer_htmlwidget(..., type = "text/html; charset=UTF-8")
 
-serializer_device(type, dev_on, dev_off = grDevices::dev.off)
+serializer_device(
+  type,
+  dev_on,
+  dev_off = grDevices::dev.off,
+  serializer_params = list()
+)
 
 serializer_jpeg(..., type = "image/jpeg")
 
@@ -114,6 +119,8 @@ The graphics device \code{dev_on} function will receive any arguments supplied t
 \code{filename} points to the temporary file name that should be used when saving content.}
 
 \item{dev_off}{Function to turn off the graphics device. Defaults to \code{\link[grDevices:dev]{grDevices::dev.off()}}}
+
+\item{serializer_params}{More docs needed here}
 }
 \description{
 Serializers are used in Plumber to transform the R object produced by a


### PR DESCRIPTION
## Pull Request

First attempt at #837

## Still to do:

- [ ] Lots of QA - both manual and unit tests
- [ ] Lots of Docs
- [ ] Merging with the other open PRs - this is going to be a bit of a **mess** now :/
- [ ] News.md
- [ ] devtools::Check Package
- [ ] Review
- [ ] Possibly more granular control on parameters - do we want to turn things on/off per endpoint? do we want more options? (e.g. quality)? do we want less?

### To consider

* breaking backward compatibility - don't think it does - but it's possible...
* is hard to understand - possibly
* is hard to maintain in the future - possibly ... but no worse than the rest of plumber? there's some technical debt building up in the open api params I think

## Minimal reproducible example

Have run:
```
devtools::load_all()
library(tidyverse)

#* @apiTitle Plumber Example API
#* @apiDescription Plumber example description.

#* Plot out data from the iris dataset
#* @param spec If provided, filter the data to only this species (e.g. 'setosa')
#* @get /plot
#* @serializer png
function(spec = "setosa"){
  myData <- iris
  title <- "All Species"

  # Filter if the species was specified
  if (!missing(spec)){
    title <- paste0("Only the '", spec, "' Species")
    myData <- subset(iris, Species == spec)
  }

  plot(myData$Sepal.Length, myData$Petal.Length,
       main=title, xlab="Sepal Length", ylab="Petal Length")
}
```


This shows as:
![image](https://user-images.githubusercontent.com/533662/210602875-62751d1a-e1f7-4ffc-80c3-c8a4f92e7ebf.png)

and:
![image](https://user-images.githubusercontent.com/533662/210603776-633be199-b5c3-4c20-ba47-1c837f416719.png)

Seems to work... 👍 