### PR TITLE
fix: Correct the proxy_pass of lb

### DIFF
--- a/vignettes/hosting.Rmd
+++ b/vignettes/hosting.Rmd
@@ -272,7 +272,7 @@ So the `location /app1/` block becomes:
 
 ```
 location /app1/ {
-  proxy_pass http://lb:8000/;
+  proxy_pass http://lb/;
   proxy_set_header Host $host;
 }
 ```


### PR DESCRIPTION
- haproxy actually serves on port 80

Issue https://github.com/rstudio/plumber/issues/791
