### PR TITLE
Vignette example missing Pipe

### DIFF
--- a/vignettes/execution-model.Rmd
+++ b/vignettes/execution-model.Rmd
@@ -92,7 +92,7 @@ It may be useful to define a function that you want to run as your API is closin
 pr("plumber.R") %>%
   pr_hook("exit", function(){
     print("Bye bye!")
-  })
+  }) %>%
   pr_run()
 ```
 


### PR DESCRIPTION
Without the pipe operator, the Vignette API launch example doesn't work.
