### PR TITLE
Add a zip attachment example

### DIFF
--- a/inst/plumber/16-attachment/plumber.R
+++ b/inst/plumber/16-attachment/plumber.R
@@ -21,3 +21,32 @@ function() {
 function() {
   Sys.time()
 }
+
+
+#* Write and return multiple files as an archive. Ex: `datasets.zip`
+#* @serializer octet
+#* @get /datasets
+function() {
+
+  # Create temporary directory structure
+  rnd_dir <- rawToChar(as.raw(sample(65:90, size = 5, replace = TRUE)))
+  tmp_dir <- file.path(tempdir(), rnd_dir)
+  dir.create(tmp_dir, showWarnings = FALSE)
+  on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
+
+  # Save datasets to csv
+  csv_files <- character()
+  for (dataset in c("mtcars", "iris", "airquality")) {
+    csv_file <- file.path(tmp_dir, paste0(dataset, ".csv"))
+    csv_files <- c(csv_files, csv_file)
+    write.csv(get(dataset), csv_file)
+  }
+
+  # Create archive
+  zip_file <- file.path(tmp_dir, "datasets.zip")
+  zip(zip_file, csv_files, flags = "-jq9X")
+  val <- readBin(zip_file, "raw", file.info(zip_file)$size)
+
+  as_attachment(val, "datasets.zip")
+
+}


### PR DESCRIPTION
How to return multiple object in an archive. Adding an example. Not sure, if it should be added as a feature or the right API for it either.

```r
as_attachment <- function(value, filename, ..., .list = NULL) {
  ...
}
```
What if the user wants to use different serializers for each file?

At least this is an example for the current version of plumber.
