### PR TITLE
Add support for quoted boundary for multipart request parsing.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # plumber (development version)
 
+* Add support for quoted boundary for multipart request parsing. (@meztez #924)
 
 # plumber 1.2.1
 

--- a/R/parse-body.R
+++ b/R/parse-body.R
@@ -519,6 +519,7 @@ parser_multi <- function() {
     if (!stri_detect_fixed(content_type, "boundary=", case_insensitive = TRUE))
       stop("No boundary found in multipart content-type header: ", content_type)
     boundary <- stri_match_first_regex(content_type, "boundary=([^; ]{2,})", case_insensitive = TRUE)[,2]
+    boundary <- stri_replace_first_regex(boundary, '^"([^"]+)"?', "$1")
     toparse <- parse_multipart(value, boundary)
 
     # set the names of the items as the `name` of each item

--- a/tests/testthat/test-parse-body.R
+++ b/tests/testthat/test-parse-body.R
@@ -261,6 +261,12 @@ test_that("Test multipart parser", {
   expect_true(is.raw(body_args[["img2"]][["ragnarok_small.png"]]))
   expect_gt(length(body_args[["img2"]][["ragnarok_small.png"]]), 100)
   expect_equal(body_args[["json"]], list(a=2,b=4,c=list(w=3,t=5)))
+
+  # Quoted boundary
+  req$HTTP_CONTENT_TYPE = "multipart/form-data; boundary=\"----WebKitFormBoundaryMYdShB9nBc32BUhQ\""
+  req$body <- req_body_parser(req, make_parser(c("multi", "json", "rds", "octet")))
+  expect_equal(names(req$body), c("json", "img1", "img2", "rds"))
+
 })
 
 


### PR DESCRIPTION
See #915, thanks @slodge for finding the problem and @MJSchut for pointing out the issue.

Per [RFC2046](https://www.ietf.org/rfc/rfc2046.txt)

The issue will be present in [jeroen/webutils](https://github.com/jeroen/webutils) too.

> WARNING TO IMPLEMENTORS:  The grammar for parameters on the Content-
>    type field is such that it is often necessary to enclose the boundary
>    parameter values in quotes on the Content-type line.  This is not
>    always necessary, but never hurts. Implementors should be sure to
>    study the grammar carefully in order to avoid producing invalid
>    Content-type fields.  Thus, a typical "multipart" Content-Type header
>    field might look like this:
> 
>      Content-Type: multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p
> 
>    But the following is not valid:
> 
>      Content-Type: multipart/mixed; boundary=gc0pJq0M:08jU534c0p
> 
>    (because of the colon) and must instead be represented as
> 
>      Content-Type: multipart/mixed; boundary="gc0pJq0M:08jU534c0p"
> 
>    This Content-Type value indicates that the content consists of one or
>    more parts, each with a structure that is syntactically identical to
>    an RFC 822 message, except that the header area is allowed to be
>    completely empty, and that the parts are each preceded by the line

PR task list:
- [x] Update NEWS
- [x] Add tests
- [ ] Update documentation with `devtools::document()`
