### PR TITLE
Currently swagger doc only support character version.

### DIFF
--- a/R/ui.R
+++ b/R/ui.R
@@ -171,8 +171,8 @@ unmount_openapi <- function(pr) {
 #' # * via `pr_set_docs()`
 #' # * or through URL query string variables
 #' pr() %>%
-#'   # Set default argument `version = 3` for the swagger `index` and `static` functions
-#'   pr_set_docs("swagger", version = 3) %>%
+#'   # Set default argument `version = "3"` for the swagger `index` and `static` functions
+#'   pr_set_docs("swagger", version = "3") %>%
 #'   pr_get("/plus/<a:int>/<b:int>", function(a, b) { a + b }) %>%
 #'   pr_run()
 #' }

--- a/man/register_docs.Rd
+++ b/man/register_docs.Rd
@@ -50,8 +50,8 @@ register_docs(
 # * via `pr_set_docs()`
 # * or through URL query string variables
 pr() \%>\%
-  # Set default argument `version = 3` for the swagger `index` and `static` functions
-  pr_set_docs("swagger", version = 3) \%>\%
+  # Set default argument `version = "3"` for the swagger `index` and `static` functions
+  pr_set_docs("swagger", version = "3") \%>\%
   pr_get("/plus/<a:int>/<b:int>", function(a, b) { a + b }) \%>\%
   pr_run()
 }


### PR DESCRIPTION
```r
pr() |> pr_set_docs("swagger", version = 3) |> pr_run()
```

PR task list:
- [ ] Update NEWS
- [ ] Add tests
- [x] Update documentation with `devtools::document()`
