### PR TITLE
Prevent parseUTF8 from overwriting srcfile attribute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # plumber (development version)
 
+* Fix #916, related to `parseUTF8` return value attribute `srcfile` on Windows. (#930) 
 
 # plumber 1.2.1
 

--- a/R/utf8.R
+++ b/R/utf8.R
@@ -66,15 +66,13 @@ parseUTF8 <- function(file) {
   # **can** be encoded natively on Windows (might be a bug in base R); we
   # rewrite the source code in a natively encoded temp file and parse it in this
   # case (the source reference is still pointed to the original file, though)
-  keepsource <- TRUE
   if (isWindows() && enc == 'unknown') {
     file <- tempfile(); on.exit(unlink(file), add = TRUE)
     writeLines(lines, file)
-    keepsource <- FALSE
   }
 
   # keep the source locations within the file while parsing
-  exprs <- try(parse(file, keep.source = keepsource, srcfile = src, encoding = enc))
+  exprs <- try(parse(file, keep.source = FALSE, srcfile = src, encoding = enc))
   if (inherits(exprs, "try-error")) {
     stop("Error sourcing ", file)
   }

--- a/R/utf8.R
+++ b/R/utf8.R
@@ -66,13 +66,15 @@ parseUTF8 <- function(file) {
   # **can** be encoded natively on Windows (might be a bug in base R); we
   # rewrite the source code in a natively encoded temp file and parse it in this
   # case (the source reference is still pointed to the original file, though)
+  keepsource <- TRUE
   if (isWindows() && enc == 'unknown') {
     file <- tempfile(); on.exit(unlink(file), add = TRUE)
     writeLines(lines, file)
+    keepsource <- FALSE
   }
-  
+
   # keep the source locations within the file while parsing
-  exprs <- try(parse(file, keep.source = TRUE, srcfile = src, encoding = enc))
+  exprs <- try(parse(file, keep.source = keepsource, srcfile = src, encoding = enc))
   if (inherits(exprs, "try-error")) {
     stop("Error sourcing ", file)
   }

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -1,0 +1,4 @@
+test_that("parseUTF8 has same srcfile attribute as file arg input", {
+  filename <- test_path("files/plumber.R")
+  expect_equal(attr(parseUTF8(file), "srcfile")$filename, filename)
+})

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -1,4 +1,4 @@
 test_that("parseUTF8 has same srcfile attribute as file arg input", {
   filename <- test_path("files/plumber.R")
-  expect_equal(attr(parseUTF8(file), "srcfile")$filename, filename)
+  expect_equal(attr(parseUTF8(filename), "srcfile")$filename, filename)
 })


### PR DESCRIPTION
Fix #916, related to `parseUTF8` return value attribute `srcfile` on Windows.

PR task list:
- [x] Update NEWS
- [x] Add tests
- [ ] Update documentation with `devtools::document()`
