### PR TITLE
chore: Remove parse comment to match implementation

### DIFF
--- a/R/utf8.R
+++ b/R/utf8.R
@@ -71,7 +71,6 @@ parseUTF8 <- function(file) {
     writeLines(lines, file)
   }
 
-  # keep the source locations within the file while parsing
   exprs <- try(parse(file, keep.source = FALSE, srcfile = src, encoding = enc))
   if (inherits(exprs, "try-error")) {
     stop("Error sourcing ", file)


### PR DESCRIPTION
The wanted behavior is to **not keep** the source. The comments should match. (I missed it in #930)