### PR TITLE
bug: Use `{rlang}` instead of `{ellipsis}`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Suggests:
     redoc,
     rapidoc,
     sf
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Collate:
     'async.R'
     'content-types.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,8 +32,7 @@ Imports:
     magrittr,
     mime,
     lifecycle (>= 0.2.0),
-    ellipsis (>= 0.3.0),
-    rlang
+    rlang (>= 1.0.0)
 ByteCompile: TRUE
 Suggests:
     testthat (>= 0.11.0),

--- a/R/options_plumber.R
+++ b/R/options_plumber.R
@@ -68,7 +68,7 @@ options_plumber <- function(
   sharedSecret         = getOption("plumber.sharedSecret"),
   legacyRedirects      = getOption("plumber.legacyRedirects")
 ) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
 
   # Make sure all fallback options are disabled
   if (!missing(docs.callback) && is.null(docs.callback)) {

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -173,7 +173,7 @@ Plumber <- R6Class(
         stop("Plumber router `$run()` method should not be called while `plumb()`ing a file")
       }
 
-      ellipsis::check_dots_empty()
+      rlang::check_dots_empty()
 
       # Legacy support for RStudio pro products.
       # Checks must be kept for >= 2 yrs after plumber v1.0.0 release date

--- a/R/pr.R
+++ b/R/pr.R
@@ -528,7 +528,7 @@ pr_run <- function(pr,
                    quiet = FALSE
 ) {
   validate_pr(pr)
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   pr$run(host = host,
          port = port,
          debug = debug,


### PR DESCRIPTION
Since superseded by rlang https://rlang.r-lib.org/news/#argument-intake-1-0-0