### PR TITLE
tests: Replace `with_mock()` with `with_mocked_bindings()`

### DIFF
--- a/tests/testthat/test-parse-body.R
+++ b/tests/testthat/test-parse-body.R
@@ -25,15 +25,15 @@ test_that("filter passes on content-type", {
     body = "this is a body",
     HTTP_CONTENT_TYPE = "text/html; charset=testset",
   )
-  with_mock(
+  local_mocked_bindings(
     parse_body = function(body, content_type = "unknown", parsers = NULL) {
       print(content_type)
       body
-    },
-    {
-      expect_output(req_body_parser(req, make_parser("text")), "text/html; charset=testset")
-    },
-    .env = "plumber"
+    }
+  )
+  expect_output(
+    req_body_parser(req, make_parser("text")),
+    "text/html; charset=testset"
   )
 })
 

--- a/tests/testthat/test-plumber-run.R
+++ b/tests/testthat/test-plumber-run.R
@@ -100,37 +100,34 @@ test_that("`debug` is not set until runtime", {
   skip_if_not_installed("mockery", "0.4.2")
 
   m <- mockery::mock(TRUE, cycle = TRUE)
-  # https://github.com/r-lib/testthat/issues/734#issuecomment-377367516
-  # > It should work if you fully qualify the function name (include the pkgname)
-  with_mock("plumber:::default_debug" = m, {
-    root <- pr()
-    root$getDebug()
-    mockery::expect_called(m, 1)
+  local_mocked_bindings(default_debug = m)
 
-    with_interrupt({
-      root %>% pr_run(quiet = TRUE)
-    })
-    # increase by 1
-    mockery::expect_called(m, 2)
+  root <- pr()
+  root$getDebug()
+  mockery::expect_called(m, 1)
 
-    # listen to set value
-    with_interrupt({
-      root %>%
-        pr_set_debug(TRUE) %>%
-        pr_run(quiet = TRUE)
-    })
-    # not updated. stay at 2
-    mockery::expect_called(m, 2)
-
-    # listen to run value
-    with_interrupt({
-      root %>%
-        pr_run(debug = FALSE, quiet = TRUE)
-    })
-    # not updated. stay at 2
-    mockery::expect_called(m, 2)
-
-    # TODO test that run(debug=) has preference over pr_set_debug()
+  with_interrupt({
+    root %>% pr_run(quiet = TRUE)
   })
+  # increase by 1
+  mockery::expect_called(m, 2)
 
+  # listen to set value
+  with_interrupt({
+    root %>%
+      pr_set_debug(TRUE) %>%
+      pr_run(quiet = TRUE)
+  })
+  # not updated. stay at 2
+  mockery::expect_called(m, 2)
+
+  # listen to run value
+  with_interrupt({
+    root %>%
+      pr_run(debug = FALSE, quiet = TRUE)
+  })
+  # not updated. stay at 2
+  mockery::expect_called(m, 2)
+
+  # TODO test that run(debug=) has preference over pr_set_debug()
 })


### PR DESCRIPTION
Fixes #969