### PR TITLE
Avoid disk I/O during parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Fixes #956, allowing a port to be specified as an environment variable. User-provided ports must be between 1024 and 49151 (following [IANA guidelines](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml)) and may not be a known unsafe port. plumber will now throw an error if an invalid port is requested. (@shikokuchuo @gadenbuie #963)
 
 * Added support for graphic devices provided by ragg and svglite (@thomasp85 #964)
+* `parse_rds()`, `parse_feather()`, and `parse_parquet()` no longer writes data to disk during parsing (@thomasp85, #942)
 
 # plumber 1.2.2
 

--- a/R/parse-body.R
+++ b/R/parse-body.R
@@ -474,32 +474,40 @@ parser_read_file <- function(read_fn = readLines) {
 #' @describeIn parsers RDS parser. See [readRDS()] for more details.
 #' @export
 parser_rds <- function(...) {
-  parser_read_file(function(tmpfile) {
-    # `readRDS()` does not work with `rawConnection()`
-    readRDS(tmpfile, ...)
-  })
+  parse_fn <- function(raw_val) {
+    unserialize(memDecompress(raw_val))
+  }
+  function(value, ...) {
+    parse_fn(value)
+  }
 }
 
 #' @describeIn parsers feather parser. See [arrow::read_feather()] for more details.
 #' @export
 parser_feather <- function(...) {
-  parser_read_file(function(tmpfile) {
-    if (!requireNamespace("arrow", quietly = TRUE)) {
-      stop("`arrow` must be installed for `parser_feather` to work")
-    }
-    arrow::read_feather(tmpfile, ...)
-  })
+  if (!requireNamespace("arrow", quietly = TRUE)) {
+    stop("`arrow` must be installed for `parser_feather` to work")
+  }
+  parse_fn <- function(raw_val) {
+    arrow::read_feather(raw_val, ...)
+  }
+  function(value, ...) {
+    parse_fn(value)
+  }
 }
 
 #' @describeIn parsers parquet parser. See [arrow::read_parquet()] for more details.
 #' @export
 parser_parquet <- function(...) {
-  parser_read_file(function(tmpfile) {
-    if (!requireNamespace("arrow", quietly = TRUE)) {
-      stop("`arrow` must be installed for `parser_parquet` to work")
-    }
-    arrow::read_parquet(tmpfile, ...)
-  })
+  if (!requireNamespace("arrow", quietly = TRUE)) {
+    stop("`arrow` must be installed for `parser_feather` to work")
+  }
+  parse_fn <- function(raw_val) {
+    arrow::read_parquet(raw_val, ...)
+  }
+  function(value, ...) {
+    parse_fn(value)
+  }
 }
 
 #' @describeIn parsers Octet stream parser. Returns the raw content.


### PR DESCRIPTION
Fix #942 

On top of removing the need to write RDS data to a file before reading it I also removed the disk I/O for feather and parquet parsing, which was straightforward as they natively support reading from a raw vector