### PR TITLE
Actually use apiPath when mounting the docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Added support for graphic devices provided by ragg and svglite (@thomasp85 #964)
 * `parse_rds()`, `parse_feather()`, and `parse_parquet()` no longer writes data to disk during parsing (@thomasp85, #942)
+* Fixed a bug where setting the `apiPath` option wouldn't be honored when running the app (@thomasp85, #836)
 
 # plumber 1.2.2
 

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -254,7 +254,6 @@ Plumber <- R6Class(
         old_wd <- setwd(dirname(private$filename))
         on.exit({setwd(old_wd)}, add = TRUE)
       }
-
       if (isTRUE(docs_info$enabled)) {
         mount_docs(
           pr = self,
@@ -264,7 +263,7 @@ Plumber <- R6Class(
           callback = swaggerCallback,
           quiet = quiet
         )
-        on.exit(unmount_docs(self, docs_info), add = TRUE)
+        #on.exit(unmount_docs(self, docs_info), add = TRUE)
       }
 
       on.exit(private$runHooks("exit"), add = TRUE)

--- a/R/ui.R
+++ b/R/ui.R
@@ -117,7 +117,8 @@ mount_openapi <- function(pr, api_url) {
       break
     }
   }
-  pr$handle("GET", "/openapi.json", openapi_fun, serializer = serializer_unboxed_json())
+  path <- get_option_or_env("plumber.apiPath", "")
+  pr$handle("GET", paste0(path, "/openapi.json"), openapi_fun, serializer = serializer_unboxed_json())
 
   invisible()
 }
@@ -184,7 +185,7 @@ register_docs <- function(name, index, static = NULL) {
   stopifnot(is.function(index))
   if (!is.null(static)) stopifnot(is.function(static))
 
-  docs_root <- paste0("/__docs__/")
+  docs_root <- "/__docs__/"
   docs_paths <- c("/index.html", "/")
   mount_docs_func <- function(pr, api_url, ...) {
     # Save initial extra argument values
@@ -210,8 +211,11 @@ register_docs <- function(name, index, static = NULL) {
       message("Overwritting existing `", docs_root, "` mount")
       message("")
     }
-
-    pr$mount(docs_root, docs_router)
+    
+    pr$mount(
+      paste0(get_option_or_env("plumber.apiPath", ""), docs_root),
+      docs_router
+    )
 
     # add legacy swagger redirects (RStudio Connect)
     redirect_info <- swagger_redirects()


### PR DESCRIPTION
Fix #836 

The `apiPath` option was never used during the actual mounting of the docs router - only for reporting the url of it.

This is now fixed. 

@schloerke can you please advise me where tests for this bug (and the fix) are best placed?