### PR TITLE
improve forward docs a bit

### DIFF
--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -6,8 +6,21 @@ forward_class <- "plumber_forward"
 #' to pass control off to the next handler in the chain. If this is not called
 #' by a filter, the assumption is that the filter fully handled the request
 #' itself and no other filters or endpoints should be evaluated for this
-#' request.
+#' request. `forward()` cannot be used within handlers to trigger the next
+#' matching handler in the router. It only has relevance for filters.
+#'
 #' @export
+#'
+#' @examples
+#' \dontrun{
+#' pr() %>%
+#'   pr_filter("foo", function(req, res) {
+#'     print("This is filter foo")
+#'     forward()
+#'   }) %>%
+#'   pr_run()
+#' }
+#'
 forward <- function() {
   exec <- getCurrentExec()
   exec$forward <- TRUE

--- a/man/forward.Rd
+++ b/man/forward.Rd
@@ -11,5 +11,17 @@ This function is used when a filter is done processing a request and wishes
 to pass control off to the next handler in the chain. If this is not called
 by a filter, the assumption is that the filter fully handled the request
 itself and no other filters or endpoints should be evaluated for this
-request.
+request. \code{forward()} cannot be used within handlers to trigger the next
+matching handler in the router. It only has relevance for filters.
+}
+\examples{
+\dontrun{
+pr() \%>\%
+  pr_filter("foo", function(req, res) {
+    print("This is filter foo")
+    forward()
+  }) \%>\%
+  pr_run()
+}
+
 }


### PR DESCRIPTION
Fix #831 

While we may have reservations about `forward()` it is an integral part of the current API. This PR adds a bit to the docs about where and how to use it