### PR TITLE
chore: Add CLAUDE and Copilot instructions, update install docs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -27,3 +27,4 @@ rsconnect
 ^legacy_support.txt$
 ^codecov\.yml$
 ^CRAN-SUBMISSION$
+^.claude$

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ Before you file an issue, please upgrade to the latest development of plumber fr
 
 # First, restart R.
 # To install latest plumber from GitHub:
-remotes::install_github("rstudio/plumber")
+pak::pkg_install("rstudio/plumber")
 
 See Shiny's guide to writing good bug reports for general guidance: https://github.com/rstudio/shiny/wiki/Writing-Good-Bug-Reports. The better your report is, the likelier we are to be able to reproduce and ultimately solve it.
 -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,458 @@
+# GitHub Copilot Instructions for plumber
+
+The plumber package enables creating web APIs by decorating R functions with roxygen2-style comments. It provides annotation-driven API definition, automatic OpenAPI spec generation, and built-in Swagger UI. This R package follows standard R package development practices using the devtools ecosystem.
+
+**CRITICAL: Always follow these instructions first and only fallback to additional search and context gathering if the information in these instructions is incomplete or found to be in error.**
+
+## Working Effectively
+
+### Essential Setup Commands
+
+Install required R and development dependencies:
+
+```bash
+# Install R if not available (Ubuntu/Debian)
+sudo apt-get update
+sudo apt-get install -y r-base r-base-dev build-essential libcurl4-openssl-dev libssl-dev libxml2-dev
+
+# Install core R packages via apt (faster than CRAN for basic packages)
+sudo apt-get install -y r-cran-jsonlite r-cran-httpuv r-cran-r6 r-cran-stringi r-cran-crayon r-cran-lifecycle r-cran-magrittr r-cran-mime r-cran-rlang r-cran-sodium r-cran-testthat
+
+# Install additional development packages if available via apt
+sudo apt-get install -y r-cran-devtools r-cran-knitr r-cran-rmarkdown r-cran-spelling
+
+# If packages not available via apt, install via CRAN (may fail if network restricted)
+sudo R -e "install.packages(c('devtools', 'pkgdown'), repos='https://cloud.r-project.org/')"
+```
+
+### Build and Development Commands
+
+Always run these commands from the package root directory:
+
+```bash
+# Install package from source (basic development workflow)
+# TIMING: ~5-10 seconds
+sudo R -e "install.packages('.', type = 'source', repos = NULL)"
+
+# Generate documentation from roxygen2 comments (if devtools available)
+R -e "devtools::document()"
+
+# Load package for interactive development
+R -e "devtools::load_all()"
+
+# Build source package without vignettes (fastest option)
+# TIMING: ~0.5 seconds - VERY FAST
+R CMD build --no-build-vignettes .
+
+# Basic R CMD check (without tests/vignettes to avoid missing dependencies)
+# TIMING: ~20-30 seconds - NEVER CANCEL, Set timeout to 60+ seconds
+_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-vignettes --no-tests plumber_*.tar.gz
+
+# Full R CMD check with devtools (if available)
+# NEVER CANCEL: Takes 5-20 minutes with all dependencies. Set timeout to 30+ minutes.
+R -e "devtools::check()"
+
+# Run unit tests directly from source
+# TIMING: ~15-30 seconds - NEVER CANCEL, Set timeout to 60+ seconds
+R -e "library(testthat); library(plumber); test_dir('tests/testthat')"
+
+# Run unit tests using devtools (if available)
+R -e "devtools::test()"
+
+# Run specific test file
+R -e "testthat::test_file('tests/testthat/test-plumber.R')"
+
+# Run tests matching a pattern
+R -e "testthat::test_file('tests/testthat/test-plumber.R', filter = 'routing')"
+```
+
+### Testing Commands
+
+```bash
+# Run full test suite from source directory
+# TIMING: ~15-30 seconds - NEVER CANCEL, Set timeout to 60+ seconds
+R -e "library(testthat); library(plumber); test_dir('tests/testthat')"
+
+# Run spelling checks (if spelling package available)
+R -e "spelling::spell_check_test(vignettes = TRUE, error = TRUE, skip_on_cran = TRUE)"
+
+# Run single test file
+R -e "testthat::test_file('tests/testthat/test-serializer.R')"
+
+# Check if package loads correctly and can create a basic API
+R -e "library(plumber); pr <- pr(); pr %>% pr_get('/test', function() 'OK'); cat('Plumber API created successfully\n')"
+```
+
+### Running Example APIs
+
+```bash
+# Run an example API from inst/plumber/
+R -e "library(plumber); pr('inst/plumber/10-welcome/plumber.R') %>% pr_run(port = 8000)"
+
+# Test basic API creation and routing
+R -e "library(plumber); pr() %>% pr_get('/health', function() list(status='ok')) %>% pr_run(port = 8000)"
+```
+
+### Documentation Commands
+
+```bash
+# Build package documentation website (if pkgdown available)
+# NEVER CANCEL: Takes 5-15 minutes. Set timeout to 20+ minutes.
+R -e "pkgdown::build_site()"
+
+# Render specific vignette (if knitr/rmarkdown available)
+R -e "rmarkdown::render('vignettes/quickstart.Rmd')"
+```
+
+## Validation Requirements
+
+### Always Test These Scenarios After Making Changes:
+
+1. **Basic Package Loading**: Verify the package loads without errors
+
+   ```r
+   library(plumber)
+   # Should load successfully with all dependencies
+   ```
+
+2. **Basic API Creation**: Test core plumber functionality
+
+   ```r
+   library(plumber)
+   pr <- pr()
+   pr %>%
+     pr_get("/hello", function(name = "world") {
+       list(message = paste("Hello", name))
+     })
+   # API should be created successfully
+   ```
+
+3. **Annotation Parsing**: Test that annotation-based APIs work
+
+   ```r
+   library(plumber)
+   pr("inst/plumber/01-append/plumber.R")
+   # Should parse without errors
+   ```
+
+4. **Serialization**: Verify core serializers work
+
+   ```r
+   library(plumber)
+   pr() %>%
+     pr_get("/json", function() list(data = 1:5), serializer = serializer_json()) %>%
+     pr_get("/html", function() "<h1>Test</h1>", serializer = serializer_html())
+   # Should handle multiple serializers
+   ```
+
+5. **Integration Testing**: Verify core dependencies work together
+   ```r
+   library(httpuv)
+   library(jsonlite)
+   library(plumber)
+   library(R6)
+   # All should load without conflicts
+   ```
+
+### Mandatory Pre-Commit Checks:
+
+**CRITICAL**: Run these validation steps before committing any changes:
+
+```bash
+# 1. Build package to check for syntax/dependency errors
+# TIMING: ~0.5 seconds - VERY FAST
+R CMD build --no-build-vignettes .
+
+# 2. Install package to verify it works
+# TIMING: ~5-10 seconds
+sudo R -e "install.packages('.', type = 'source', repos = NULL)"
+
+# 3. Test package loading and basic functionality
+# TIMING: ~2-3 seconds
+R -e "library(plumber); pr() %>% pr_get('/test', function() 'OK')"
+
+# 4. Run test suite if testthat is available
+# TIMING: ~15-30 seconds - NEVER CANCEL, Set timeout to 60+ seconds
+R -e "library(testthat); library(plumber); test_dir('tests/testthat')"
+
+# 5. Full check if time permits (optional but recommended)
+# TIMING: ~20-30 seconds - NEVER CANCEL, Set timeout to 60+ seconds
+_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-vignettes --no-tests plumber_*.tar.gz
+```
+
+**Expected timing summary**:
+
+- Basic build: ~0.5 seconds - **INSTANT**
+- Package install: ~5-10 seconds - **VERY FAST**
+- Test suite: ~15-30 seconds - **NEVER CANCEL, timeout 60+ seconds**
+- Basic check: ~20-30 seconds - **NEVER CANCEL, timeout 60+ seconds**
+- Full devtools::check(): 5-20 minutes - **NEVER CANCEL, timeout 30+ minutes**
+
+## Repository Structure
+
+### Core Development Files:
+
+- `R/` - Main R source code (60+ files including plumber.R, plumber-step.R, serializer.R)
+- `tests/testthat/` - Unit tests using testthat framework
+- `vignettes/` - 11 comprehensive documentation vignettes
+- `inst/plumber/` - 17 example APIs demonstrating all features
+- `man/` - Generated documentation (do not edit manually)
+
+### Key Architecture Components:
+
+- **Plumber Class** (`R/plumber.R`): Main R6-based router with request handling (~845 lines)
+- **Hookable Base** (`R/hookable.R`): Hook system for preroute, postroute, preserialize, etc.
+- **PlumberStep** (`R/plumber-step.R`): Base class for endpoints and filters
+- **Annotation Parser** (`R/plumb-block.R`): Parses roxygen2-style comments into routes
+- **Serializers** (`R/serializer.R`): 28+ output formats (json, html, png, csv, etc.)
+- **Parsers** (`R/parse-body.R`, `R/parse-query.R`): Request body and query string parsing
+- **OpenAPI** (`R/openapi-spec.R`, `R/openapi-types.R`): Automatic API spec generation
+- **Async Support** (`R/async.R`): Promise-based async execution with runSteps()
+
+### Dependencies (Auto-installed via devtools):
+
+- **Core (Imports)**: crayon, httpuv (>= 1.5.5), jsonlite (>= 0.9.16), lifecycle (>= 1.0.0), magrittr, mime, promises (>= 1.1.0), R6 (>= 2.0.0), rlang (>= 1.0.0), sodium, stringi (>= 0.3.0), swagger (>= 3.33.0), webutils (>= 1.1)
+- **Optional (Suggests)**: arrow, base64enc, coro, future, geojsonsf, htmlwidgets, later, ragg, rapidoc, readr, readxl, redoc, rmarkdown, rstudioapi, sf, spelling, svglite, testthat (>= 0.11.0), utils, visNetwork, writexl, yaml
+- **Development**: devtools, knitr, pkgdown, Cairo, r-quantities/units
+
+## GitHub Actions / CI Information
+
+The package uses RStudio's shiny-workflows for CI/CD (`.github/workflows/R-CMD-check.yaml`):
+
+- Automated R CMD check on push/PR and weekly (Monday 7am)
+- Website deployment via pkgdown
+- Code formatting and routine checks
+- Runs on multiple R versions and platforms
+
+**Local validation should match CI requirements**: Always run `devtools::check()` locally before pushing.
+
+## Common Development Tasks
+
+### Adding New Endpoints to APIs:
+
+1. **Annotation-based** (recommended for file-based APIs):
+
+   ```r
+   #* Description of endpoint
+   #* @get /path
+   #* @serializer json
+   function(param1, param2) {
+     # Implementation
+   }
+   ```
+
+2. **Programmatic** (recommended for dynamic APIs):
+   ```r
+   pr() %>%
+     pr_get("/path", function(param1, param2) {
+       # Implementation
+     })
+   ```
+
+### Adding New Serializers:
+
+1. Create serializer function in `R/serializer.R`
+2. Document with roxygen2 comments
+3. Register in `.onLoad()` hook: `register_serializer("name", func, "content/type")`
+4. Add tests in `tests/testthat/test-serializer.R`
+5. Update documentation
+
+### Adding New Parsers:
+
+1. Create parser function in `R/parse-body.R` or `R/parse-query.R`
+2. Document with roxygen2 comments
+3. Register in `.onLoad()` hook: `register_parser("name", func, "content/type")`
+4. Add tests in `tests/testthat/test-body-parser.R`
+5. Update documentation
+
+### Working with Vignettes:
+
+```bash
+# Build specific vignette
+R -e "rmarkdown::render('vignettes/quickstart.Rmd')"
+
+# Build all vignettes (part of pkgdown::build_site)
+R -e "devtools::build_vignettes()"
+```
+
+### Testing Example APIs:
+
+```bash
+# Run example API interactively
+R -e "library(plumber); pr('inst/plumber/01-append/plumber.R') %>% pr_run(port = 8000)"
+
+# Test that all examples parse correctly
+for dir in inst/plumber/*/; do
+  echo "Testing $dir"
+  R -e "library(plumber); pr('${dir}plumber.R')"
+done
+```
+
+## Architecture Deep Dive
+
+### R6 Class Hierarchy
+
+```
+Hookable (base class - provides hook system)
+  └── Plumber (main API router)
+        ├── PlumberStatic (static file serving)
+        └── PlumberStep (execution lifecycle base)
+              ├── PlumberEndpoint (terminal request handlers)
+              └── PlumberFilter (middleware)
+```
+
+### Request Processing Pipeline
+
+1. **Request arrives** → `Plumber$call()` invoked (R/plumber.R:565-846)
+2. **Pre-route hooks** execute (auth, logging, request modification)
+3. **Route matching** in priority order:
+   - `"__first__"` preempted endpoints (highest priority)
+   - Filters execute sequentially with `forward()` continuation
+   - Endpoints checked at each preemption level
+   - Mounted sub-routers (`pr_mount()`)
+   - 404 handler if no match
+4. **Post-route hooks** execute (after handler, before serialization)
+5. **Serialization**:
+   - Pre-serialize hooks (modify response object)
+   - Serializer function application
+   - Post-serialize hooks (modify final output)
+6. **HTTP response** returned
+
+### Annotation System
+
+Annotations are parsed by `plumbBlock()` in `R/plumb-block.R`:
+
+- Scans backward from function to find `#*` or `#'` comments
+- Uses regex to parse structured tags into metadata
+- `evaluateBlock()` creates `PlumberEndpoint` or `PlumberFilter` objects
+
+**Annotation order matters**: Place route-modifying annotations before HTTP verb:
+
+```r
+#* @serializer json     # ✓ Correct order
+#* @get /data
+```
+
+### Path Parameter Types
+
+Supported types in path parameters (`/users/<id:int>`):
+
+- `int` - Integer conversion
+- `double`, `numeric` - Numeric conversion
+- `bool`, `logical` - Boolean conversion
+- `string` - String (default)
+- `[type]` - Arrays (e.g., `[int]`)
+
+## Troubleshooting
+
+### Common Issues:
+
+- **Missing Dependencies**: Install core packages via apt first, then try CRAN for others
+  ```bash
+  sudo apt-get install -y r-cran-jsonlite r-cran-httpuv r-cran-r6 r-cran-stringi r-cran-crayon r-cran-lifecycle r-cran-magrittr r-cran-mime r-cran-rlang r-cran-sodium r-cran-testthat
+  ```
+- **Package Won't Load**: Reinstall from source: `sudo R -e "install.packages('.', type = 'source', repos = NULL)"`
+- **devtools Not Available**: Use R CMD directly for basic operations
+- **Test Failures**: Ensure package is installed: tests need the package loaded
+- **Build Failures**: Check DESCRIPTION file dependencies match actual imports
+- **Port Already in Use**: Change port when running examples: `pr_run(port = 8001)`
+
+### Filters Must Call forward()
+
+A common mistake is forgetting to call `forward()` in filters:
+
+```r
+#* @filter logger
+function(req) {
+  log(req$PATH_INFO)
+  forward()  # Required! Without this, request stops here
+}
+```
+
+### Annotation Parser Gotchas:
+
+- Annotations must use `#*` prefix (not regular `#` comments)
+- Annotations apply to the next function definition
+- Multiple endpoints require multiple function definitions
+- Router-level config uses `#* @plumber` tag
+
+### Alternative Commands When devtools Unavailable:
+
+```bash
+# Use R CMD instead of devtools equivalents:
+R CMD build --no-build-vignettes .                    # instead of devtools::build()
+_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-vignettes --no-tests *.tar.gz  # instead of devtools::check()
+R -e "library(testthat); test_dir('tests/testthat')"  # instead of devtools::test()
+sudo R -e "install.packages('.', type='source', repos=NULL)"  # instead of devtools::install()
+```
+
+### Network/CRAN Issues:
+
+If CRAN mirrors are unavailable, use apt packages or local installation:
+
+```bash
+# Prefer apt packages over CRAN when possible
+sudo apt-cache search r-cran- | grep <package_name>
+
+# Force local installation without network
+sudo R -e "install.packages('.', type='source', repos=NULL)"
+```
+
+### File Loading Order (Collate):
+
+R requires specific file load order due to dependencies. The `Collate` field in DESCRIPTION enforces:
+
+1. Base classes first: `async.R`, `hookable.R`
+2. Core infrastructure: `plumber.R`, `plumber-step.R`
+3. Features: parsers, serializers, OpenAPI
+4. Utilities: `utils.R`, `zzz.R` (last - package hooks)
+
+When adding new files, consider load order dependencies and update DESCRIPTION Collate field.
+
+## Important Files Reference
+
+### Core Routing & Execution:
+
+- `R/plumber.R` - Main Plumber class (845 lines)
+- `R/plumber-step.R` - Step/Endpoint/Filter classes
+- `R/hookable.R` - Hook system base class
+- `R/async.R` - Promise/async execution engine
+
+### API Definition:
+
+- `R/plumb.R` - `plumb()` entry point
+- `R/plumb-block.R` - Annotation parser
+- `R/pr.R` - Programmatic API (`pr()` constructor)
+- `R/pr_set.R` - Configuration methods (`pr_set_*()`)
+
+### Data Handling:
+
+- `R/serializer.R` - Output serialization (28+ formats)
+- `R/parse-body.R` - Request body parsing
+- `R/parse-query.R` - Query string parsing
+
+### OpenAPI/Documentation:
+
+- `R/openapi-spec.R` - OpenAPI 3.0 generation
+- `R/openapi-types.R` - Type inference
+- `R/ui.R` - Swagger/Rapidoc/Redoc UI mounting
+
+### Example APIs (`inst/plumber/` directory):
+
+- `01-append` - Basic GET/POST
+- `02-filters` - Middleware patterns
+- `06-sessions` - Session management
+- `12-entrypoint` - Entrypoint pattern
+- `13-promises`, `14-future` - Async examples
+- `15-openapi-spec` - OpenAPI customization
+
+### Test Files (`tests/testthat/` directory):
+
+- `test-plumber.R` - Core router tests
+- `test-serializer.R` - Serializer tests
+- `test-body-parser.R` - Parser tests
+- `test-endpoint.R` - Endpoint tests
+- `test-filter.R` - Filter tests
+- `helper-mock-request.R` - Test utilities
+
+**Remember**: This is a web API framework for R. Always consider HTTP semantics, request/response handling, serialization, and the annotation parsing system when making changes. The dual API design (annotation-based and programmatic) should both be supported for any new features.

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 inst/doc
 docs
 rsconnect
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,378 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Plumber is an R package that enables creating web APIs by decorating R functions with roxygen2-style comments. It provides annotation-driven API definition (`#* @get /path`), automatic OpenAPI spec generation, and built-in Swagger UI.
+
+**Current version:** 1.3.0.9000 (development)
+
+## Essential Commands
+
+### Package Development
+```r
+# Install development version
+pak::pkg_install("rstudio/plumber")
+
+# Load package for interactive development
+devtools::load_all()
+
+# Build and check package
+devtools::check()
+
+# Generate documentation from roxygen comments
+devtools::document()
+
+# Run all tests
+devtools::test()
+
+# Run specific test file
+testthat::test_file("tests/testthat/test-plumber.R")
+
+# Run tests matching a pattern
+testthat::test_file("tests/testthat/test-plumber.R", filter = "routing")
+```
+
+### Running Example APIs
+```r
+# Run an example API from inst/plumber/
+pr("inst/plumber/10-welcome/plumber.R") %>% pr_run(port = 8000)
+
+# Or for development testing
+library(plumber)
+pr("path/to/test-api.R") %>% pr_run(port = 8000)
+```
+
+### Testing via Command Line
+```bash
+# Run full R CMD check
+R CMD build . && R CMD check plumber_*.tar.gz
+
+# Run tests only
+Rscript -e "devtools::test()"
+
+# Run specific test file
+Rscript -e "testthat::test_file('tests/testthat/test-plumber.R')"
+```
+
+## Architecture
+
+### R6 Class Hierarchy
+
+The package uses R6 for object-oriented design with a clear inheritance chain:
+
+```
+Hookable (base class - provides hook system)
+  └── Plumber (main API router)
+        ├── PlumberStatic (static file serving)
+        └── PlumberStep (execution lifecycle base)
+              ├── PlumberEndpoint (terminal request handlers)
+              └── PlumberFilter (middleware)
+```
+
+**Key files:**
+- [R/hookable.R](R/hookable.R) - Hook registration and execution (preroute, postroute, preserialize, etc.)
+- [R/plumber.R](R/plumber.R) - Core `Plumber` class with routing engine
+- [R/plumber-step.R](R/plumber-step.R) - `PlumberStep`, `PlumberEndpoint`, `PlumberFilter` classes
+
+### Request Processing Pipeline
+
+Understanding the request flow is critical for debugging and extending the framework:
+
+1. **Request arrives** → `Plumber$call()` invoked ([R/plumber.R:565-846](R/plumber.R#L565-L846))
+2. **Pre-route hooks** execute (auth, logging, request modification)
+3. **Route matching** in priority order:
+   - `"__first__"` preempted endpoints (highest priority)
+   - Filters execute sequentially with `forward()` continuation
+   - Endpoints checked at each preemption level
+   - Mounted sub-routers (`pr_mount()`)
+   - 404 handler if no match
+4. **Post-route hooks** execute (after handler, before serialization)
+5. **Serialization**:
+   - Pre-serialize hooks (modify response object)
+   - Serializer function application
+   - Post-serialize hooks (modify final output)
+6. **HTTP response** returned
+
+**Forward mechanism:** Filters must call `forward()` to pass control to the next handler. This uses an execution domain pattern tracked internally.
+
+### Annotation Parsing System
+
+APIs are defined using special comments that get parsed into route metadata:
+
+**Core annotations:**
+- `#* @get /path`, `#* @post /path` - HTTP verb + route
+- `#* @serializer json` - Output format (json, html, png, csv, etc.)
+- `#* @parser json` - Input parsing (json, form, multipart, etc.)
+- `#* @param name:type Description` - Parameter documentation
+- `#* @filter name` - Define filter/middleware
+- `#* @preempt [filter_name]` - Control execution order
+- `#* @plumber` - Router-level configuration
+
+**Implementation:**
+- [R/plumb-block.R](R/plumb-block.R) - `plumbBlock()` scans backward from function to find `#*` comments
+- Uses regex to parse structured tags into metadata
+- `evaluateBlock()` creates `PlumberEndpoint` or `PlumberFilter` objects
+- Supports both `#*` (recommended) and `#'` prefixes
+
+### Plugin Architecture
+
+Three extensible registries in `.globals` environment:
+
+1. **Serializers** ([R/serializer.R](R/serializer.R)) - Transform R objects to HTTP responses
+   - 28+ built-in: json, html, png, csv, geojson, arrow, parquet, xlsx, etc.
+   - Composable via `serializer_headers()` → `serializer_content_type()` → specific serializers
+   - Register custom: `register_serializer("name", func, contentType)`
+
+2. **Parsers** ([R/parse-body.R](R/parse-body.R), [R/parse-query.R](R/parse-query.R)) - Parse request bodies
+   - Query string: `parseQS()` handles URL parameters with encoding
+   - Body parsing: Content-Type detection, multipart form support
+   - Register custom: `register_parser("name", func, contentType)`
+
+3. **Docs** ([R/ui.R](R/ui.R)) - Visual API documentation providers
+   - Built-in: swagger, rapidoc, redoc
+   - Mounted at `/__docs__/` by default
+   - OpenAPI spec at `/openapi.json`
+
+### OpenAPI Specification Generation
+
+Automatic OpenAPI 3.0 spec generation from annotations:
+
+- [R/openapi-spec.R](R/openapi-spec.R) - `$getApiSpec()` generates full spec
+- [R/openapi-types.R](R/openapi-types.R) - Type inference from R function signatures
+- Parameter metadata extracted from `@param` tags
+- Response types inferred from serializers
+- `pr_set_api_spec()` for manual spec customization
+
+### Async/Promise Support
+
+Built on the `promises` package for non-blocking execution:
+
+- [R/async.R](R/async.R) - `runSteps()` and `runStepsUntil()` handle sync/async
+- Promise detection via `is.promising(result)`
+- Recursive step execution for async handlers
+- Error handling with `%...!%` catch operator
+- Filters and endpoints can return promises
+
+### Path Parameter Extraction
+
+Regex-based path matching with type conversion:
+
+```r
+#* @get /users/<id:int>
+#* @get /files/<name:string>
+#* @get /data/<vals:[int]>     # Array of integers
+```
+
+Supported types: `int`, `double`/`numeric`, `bool`/`logical`, `string`, arrays `[type]`
+
+Implementation in [R/plumber.R](R/plumber.R) - path regex compilation and parameter extraction.
+
+## Code Organization
+
+### File Loading Order (Collate in DESCRIPTION)
+
+R requires specific file load order due to dependencies. The `Collate` field enforces:
+1. Base classes first: `async.R`, `hookable.R`
+2. Core infrastructure: `plumber.R`, `plumber-step.R`
+3. Features: parsers, serializers, OpenAPI
+4. Utilities: `utils.R`, `zzz.R` (last - package hooks)
+
+When adding new files, consider load order dependencies.
+
+### Source Code Structure
+
+**Core routing & execution:**
+- [R/plumber.R](R/plumber.R) - Main `Plumber` class (845 lines)
+- [R/plumber-step.R](R/plumber-step.R) - Step/Endpoint/Filter classes
+- [R/hookable.R](R/hookable.R) - Hook system base class
+- [R/async.R](R/async.R) - Promise/async execution engine
+
+**API definition:**
+- [R/plumb.R](R/plumb.R) - `plumb()` entry point
+- [R/plumb-block.R](R/plumb-block.R) - Annotation parser
+- [R/pr.R](R/pr.R) - Programmatic API (`pr()` constructor)
+- [R/pr_set.R](R/pr_set.R) - Configuration methods (`pr_set_*()`)
+
+**Data handling:**
+- [R/serializer.R](R/serializer.R) - Output serialization (28+ formats)
+- [R/parse-body.R](R/parse-body.R) - Request body parsing
+- [R/parse-query.R](R/parse-query.R) - Query string parsing
+
+**OpenAPI/Documentation:**
+- [R/openapi-spec.R](R/openapi-spec.R) - OpenAPI 3.0 generation
+- [R/openapi-types.R](R/openapi-types.R) - Type inference
+- [R/ui.R](R/ui.R) - Swagger/Rapidoc/Redoc UI mounting
+
+**Advanced features:**
+- [R/session-cookie.R](R/session-cookie.R) - Encrypted session cookies
+- [R/plumber-static.R](R/plumber-static.R) - Static file serving
+- [R/shared-secret-filter.R](R/shared-secret-filter.R) - Authentication
+- [R/default-handlers.R](R/default-handlers.R) - 404/405/500 handlers
+
+## Testing Strategy
+
+### Test Organization
+
+Tests in [tests/testthat/](tests/testthat/) follow clear naming:
+
+- **Unit tests:** `test-<feature>.R` (e.g., `test-serializer.R`, `test-parser.R`)
+- **Integration tests:** `test-<component>.R` (e.g., `test-plumber.R`, `test-endpoint.R`)
+- **Helper files:** `helper-<utility>.R` (e.g., `helper-mock-request.R`)
+
+### Mock Request Helper
+
+Use `make_req()` from [tests/testthat/helper-mock-request.R](tests/testthat/helper-mock-request.R) to create test requests:
+
+```r
+req <- make_req(verb = "POST", path = "/api/data", qs = "param=value", body = '{"key":"value"}')
+```
+
+### Example APIs for Testing
+
+17 complete example APIs in [inst/plumber/](inst/plumber/) demonstrate all features:
+- `01-append` - Basic GET/POST
+- `02-filters` - Middleware patterns
+- `06-sessions` - Session management
+- `12-entrypoint` - Entrypoint pattern for complex APIs
+- `13-promises`, `14-future` - Async examples
+- `15-openapi-spec` - OpenAPI customization
+
+Run examples with: `pr("inst/plumber/<example>/plumber.R") %>% pr_run()`
+
+## Development Patterns
+
+### Dual API Design
+
+Plumber supports both annotation-based and programmatic API definition:
+
+**Annotation-based (declarative):**
+```r
+#* @get /hello
+function(name = "world") {
+  list(message = paste("Hello", name))
+}
+```
+
+**Programmatic (imperative):**
+```r
+pr() %>%
+  pr_get("/hello", function(name = "world") {
+    list(message = paste("Hello", name))
+  })
+```
+
+Both approaches are first-class. Use annotations for file-based APIs, programmatic for dynamic construction.
+
+### Router Composition via Mounting
+
+Complex APIs can be composed from multiple routers:
+
+```r
+root <- pr()
+users_api <- pr("apis/users.R")
+products_api <- pr("apis/products.R")
+
+root %>%
+  pr_mount("/users", users_api) %>%
+  pr_mount("/products", products_api) %>%
+  pr_run()
+```
+
+Mounted routers maintain independent configurations (hooks, error handlers).
+
+### Entrypoint Pattern
+
+For APIs requiring initialization, use `entrypoint.R` that returns a configured router:
+
+```r
+# inst/plumber/12-entrypoint/entrypoint.R
+function(port = 8000) {
+  pr("plumber.R") %>%
+    pr_set_debug(TRUE) %>%
+    pr_cookie(secret_key) %>%
+    pr_hook("preroute", logging_hook)
+}
+```
+
+This pattern enables environment-specific configuration and dependency injection.
+
+## Package Configuration
+
+### Global Options
+
+Set via `options()` or environment variables:
+
+- `plumber.port`, `plumber.host` - Default server binding
+- `plumber.maxRequestSize` - Max body size (bytes)
+- `plumber.docs` - Enable/disable documentation UI
+- `plumber.docs.callback` - Custom docs provider
+- `plumber.apiURL`, `plumber.apiPath` - OpenAPI spec URLs
+
+See [R/options_plumber.R](R/options_plumber.R) for full list.
+
+### CI/CD Pipeline
+
+GitHub Actions workflow ([.github/workflows/R-CMD-check.yaml](.github/workflows/R-CMD-check.yaml)):
+- Runs on push to main, PRs, and weekly (Monday 7am)
+- Three jobs: website build, routine checks, R CMD check
+- Uses rstudio/shiny-workflows templates
+
+## Common Pitfalls
+
+### Annotation Order Matters
+
+Annotations are parsed top-to-bottom. Place route-modifying annotations before the HTTP verb:
+
+```r
+#* @serializer json     # ✓ Correct order
+#* @get /data
+```
+
+Not:
+```r
+#* @get /data
+#* @serializer json     # ✗ Won't apply to this endpoint
+```
+
+### Forward() is Required in Filters
+
+Filters MUST call `forward()` to continue the pipeline:
+
+```r
+#* @filter logger
+function(req) {
+  log(req$PATH_INFO)
+  forward()  # Required! Without this, request stops here
+}
+```
+
+### Path Parameters Need Type Hints
+
+Extract path params with type conversion:
+
+```r
+#* @get /users/<id:int>    # ✓ Type specified
+function(id) {
+  # id is already an integer
+}
+```
+
+Without type hint, all params are strings.
+
+### Serializer vs Parser Confusion
+
+- **Serializer** - Converts R object → HTTP response (output)
+- **Parser** - Converts HTTP request → R object (input)
+
+Use `@serializer` for response format, `@parser` for request body format.
+
+## Documentation
+
+- **Website:** https://www.rplumber.io
+- **Vignettes:** [vignettes/](vignettes/) - 11 comprehensive guides
+- **Man pages:** [man/](man/) - Generated from roxygen2 comments
+- **Cheat sheet:** https://github.com/rstudio/cheatsheets/blob/main/plumber.pdf
+
+When adding new features, update corresponding vignette and man page.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ install.packages("plumber")
 If you want to try out the latest development version, you can install it from GitHub.
 
 ```r
-remotes::install_github("rstudio/plumber")
+pak::pkg_install("rstudio/plumber")
 library(plumber)
 ```
 

--- a/scripts/revdepcheck.R
+++ b/scripts/revdepcheck.R
@@ -1,6 +1,6 @@
 source("scripts/git_clean.R")
 
-if (!require("revdepcheck")) remotes::install_github("r-lib/revdepcheck")
+if (!require("revdepcheck")) pak::pkg_install("r-lib/revdepcheck")
 
 # revdepcheck::revdep_reset()
 revdepcheck::revdep_check(num_workers = 4)


### PR DESCRIPTION
Added CLAUDE.md and .github/copilot-instructions.md to provide detailed guidance for AI coding assistants. Updated installation instructions in README, bug report template, and revdepcheck script to use pak::pkg_install() instead of remotes::install_github(). Updated .gitignore and .Rbuildignore to exclude .claude files.
