### PR TITLE
fix: Adjust swagger redirects

### DIFF
--- a/R/ui.R
+++ b/R/ui.R
@@ -3,7 +3,6 @@
 # Mount OpenAPI and Docs
 #' @noRd
 mount_docs <- function(pr, host, port, docs_info, callback, quiet = FALSE) {
-
   # return early if not enabled
   if (!isTRUE(docs_info$enabled)) {
     return()
@@ -14,9 +13,9 @@ mount_docs <- function(pr, host, port, docs_info, callback, quiet = FALSE) {
     "plumber.apiURL",
     urlHost(
       scheme = get_option_or_env("plumber.apiScheme", "http"),
-      host   = get_option_or_env("plumber.apiHost", host),
-      port   = get_option_or_env("plumber.apiPort", port),
-      path   = get_option_or_env("plumber.apiPath", ""),
+      host = get_option_or_env("plumber.apiHost", host),
+      port = get_option_or_env("plumber.apiPort", port),
+      path = get_option_or_env("plumber.apiPath", ""),
       changeHostLocation = TRUE
     )
   )
@@ -27,7 +26,9 @@ mount_docs <- function(pr, host, port, docs_info, callback, quiet = FALSE) {
   # Mount Docs
   if (length(registered_docs()) == 0) {
     if (!isTRUE(quiet)) {
-      message("No visual documentation options registered. See help(register_docs).")
+      message(
+        "No visual documentation options registered. See help(register_docs)."
+      )
     }
     return()
   }
@@ -48,7 +49,6 @@ mount_docs <- function(pr, host, port, docs_info, callback, quiet = FALSE) {
   }
 
   invisible()
-
 }
 
 # Check is Docs is available
@@ -57,7 +57,7 @@ is_docs_available <- function(docs) {
   if (isTRUE(docs %in% registered_docs())) {
     return(TRUE)
   } else {
-    message("Unknown docs \"", docs,"\". Maybe try library(", docs,").")
+    message("Unknown docs \"", docs, "\". Maybe try library(", docs, ").")
     return(FALSE)
   }
 }
@@ -65,7 +65,6 @@ is_docs_available <- function(docs) {
 # Unmount OpenAPI and Docs
 #' @noRd
 unmount_docs <- function(pr, docs_info) {
-
   # return early if not enabled
   if (!isTRUE(docs_info$enabled)) {
     return()
@@ -84,20 +83,20 @@ unmount_docs <- function(pr, docs_info) {
 #' Mount OpenAPI Specification to a plumber router
 #' @noRd
 mount_openapi <- function(pr, api_url) {
-
   spec <- pr$getApiSpec()
 
   # Create a function that's hardcoded to return the OpenAPI specification -- regardless of env.
   openapi_fun <- function(req) {
     # use the HTTP_REFERER so RSC can find the Docs location to ask
     ## (can't directly ask for 127.0.0.1)
-    if (is.null(get_option_or_env("plumber.apiURL")) &&
-        is.null(get_option_or_env("plumber.apiHost"))) {
+    if (
+      is.null(get_option_or_env("plumber.apiURL")) &&
+        is.null(get_option_or_env("plumber.apiHost"))
+    ) {
       if (is.null(req$HTTP_REFERER)) {
         # Prevent leaking host and port if option is not set
         api_url <- character(1)
-      }
-      else {
+      } else {
         # Use HTTP_REFERER as fallback
         api_url <- req$HTTP_REFERER
         api_url <- sub("(\\?.*)?$", "", api_url)
@@ -107,18 +106,28 @@ mount_openapi <- function(pr, api_url) {
     }
 
     utils::modifyList(list(servers = list(list(url = api_url))), spec)
-
   }
   # http://spec.openapis.org/oas/v3.0.3#document-structure
   # "It is RECOMMENDED that the root OpenAPI document be named: openapi.json"
-  openapi_json_path <- paste0(get_option_or_env("plumber.apiPath", ""), "/openapi.json")
+  # `plumber.apiPath` option is for the UI of the docs, not internal routing. Do not use it.
+  openapi_json_path <- paste0(
+    get_option_or_env("plumber.apiPath", ""),
+    "/openapi.json"
+  )
   for (ep in pr$endpoints[["__no-preempt__"]]) {
     if (ep$path == openapi_json_path) {
-      message("Overwritting existing `/openapi.json` route. Use `$setApiSpec()` to define your OpenAPI Spec")
+      message(
+        "Overwritting existing `/openapi.json` route. Use `$setApiSpec()` to define your OpenAPI Spec"
+      )
       break
     }
   }
-  pr$handle("GET", openapi_json_path, openapi_fun, serializer = serializer_unboxed_json())
+  pr$handle(
+    "GET",
+    openapi_json_path,
+    openapi_fun,
+    serializer = serializer_unboxed_json()
+  )
 
   invisible()
 }
@@ -179,11 +188,12 @@ unmount_openapi <- function(pr) {
 #' }
 #' @rdname register_docs
 register_docs <- function(name, index, static = NULL) {
-
   stopifnot(is.character(name) && length(name) == 1L)
   stopifnot(grepl("^[a-zA-Z0-9_]+$", name))
   stopifnot(is.function(index))
-  if (!is.null(static)) stopifnot(is.function(static))
+  if (!is.null(static)) {
+    stopifnot(is.function(static))
+  }
 
   docs_root <- "/__docs__/"
   docs_paths <- c("/index.html", "/")
@@ -201,7 +211,12 @@ register_docs <- function(name, index, static = NULL) {
 
     docs_router <- Plumber$new()
     for (path in docs_paths) {
-      docs_router$handle("GET", path, docs_index, serializer = serializer_html())
+      docs_router$handle(
+        "GET",
+        path,
+        docs_index,
+        serializer = serializer_html()
+      )
     }
     if (!is.null(static)) {
       docs_router$mount("/", PlumberStatic$new(static(...)))
@@ -221,7 +236,11 @@ register_docs <- function(name, index, static = NULL) {
     redirect_info <- swagger_redirects()
     for (path in names(redirect_info)) {
       if (router_has_route(pr, path, "GET")) {
-        message("Overwriting existing GET endpoint: ", path, ". Disable by setting `options_plumber(legacyRedirects = FALSE)`")
+        message(
+          "Overwriting existing GET endpoint: ",
+          path,
+          ". Disable by setting `options_plumber(legacyRedirects = FALSE)`"
+        )
       }
       pr_get(pr, path, redirect_info[[path]]$handler)
     }
@@ -282,10 +301,13 @@ swagger_redirects <- function() {
 
 
 register_swagger_docs_onLoad <- function() {
-  tryCatch({
-    do.call(register_docs, swagger::plumber_docs())
-  }, error = function(e) {
-    message("Could not register `swagger` docs. ", e)
-    NULL
-  })
+  tryCatch(
+    {
+      do.call(register_docs, swagger::plumber_docs())
+    },
+    error = function(e) {
+      message("Could not register `swagger` docs. ", e)
+      NULL
+    }
+  )
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -293,10 +293,17 @@ swagger_redirects <- function() {
   }
 
   path <- get_option_or_env("plumber.apiPath", "")
-  list(
-    "/__swagger__/" = to_route(paste0(path, "/__docs__/")),
-    "/__swagger__/index.html"  = to_route(paste0(path, "/__docs__/index.html"))
-  )
+  # The swagger UI should exist at the `<API_PATH>/__swagger__/` path
+  # which should redirect to a sibling `__docs__/` path
+  swagger_base <- paste0(path, "/__swagger__/")
+
+  ret <- list()
+  ret[[swagger_base]] <-
+    to_route("../__docs__/")
+  ret[[paste0(swagger_base, "index.html")]] <-
+    to_route("../__docs__/index.html")
+
+  ret
 }
 
 

--- a/tests/testthat/test-swagger-redirects.R
+++ b/tests/testthat/test-swagger-redirects.R
@@ -1,0 +1,417 @@
+context("Swagger redirects")
+
+test_that("swagger_redirects returns correct redirect structure with default apiPath", {
+  skip_if_not_installed("withr")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = NULL
+    ),
+    {
+      redirects <- swagger_redirects()
+
+      # Check that we have the expected redirect paths
+      expect_true("/__swagger__/" %in% names(redirects))
+      expect_true("/__swagger__/index.html" %in% names(redirects))
+
+      # Verify redirect structure uses relative paths
+      expect_equal(redirects[["/__swagger__/"]]$route, "../__docs__/")
+      expect_equal(
+        redirects[["/__swagger__/index.html"]]$route,
+        "../__docs__/index.html"
+      )
+
+      # Verify handler is a function
+      expect_true(is.function(redirects[["/__swagger__/"]]$handler))
+      expect_true(is.function(redirects[["/__swagger__/index.html"]]$handler))
+    }
+  )
+})
+
+test_that("swagger_redirects respects custom apiPath", {
+  skip_if_not_installed("withr")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = "/api/v1"
+    ),
+    {
+      redirects <- swagger_redirects()
+
+      # Redirect keys should include the apiPath prefix
+      expect_true("/api/v1/__swagger__/" %in% names(redirects))
+      expect_true("/api/v1/__swagger__/index.html" %in% names(redirects))
+
+      # Targets use relative paths
+      expect_equal(redirects[["/api/v1/__swagger__/"]]$route, "../__docs__/")
+      expect_equal(
+        redirects[["/api/v1/__swagger__/index.html"]]$route,
+        "../__docs__/index.html"
+      )
+    }
+  )
+})
+
+test_that("swagger_redirects returns empty list when disabled", {
+  skip_if_not_installed("withr")
+
+  withr::with_options(
+    list(plumber.legacyRedirects = FALSE),
+    {
+      redirects <- swagger_redirects()
+      expect_length(redirects, 0)
+      expect_equal(redirects, list())
+    }
+  )
+})
+
+test_that("swagger redirect handler returns 301 response", {
+  skip_if_not_installed("withr")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = NULL
+    ),
+    {
+      redirects <- swagger_redirects()
+      handler <- redirects[["/__swagger__/"]]$handler
+
+      # Create mock request and response
+      req <- make_req("GET", "/__swagger__/")
+      res <- PlumberResponse$new()
+
+      # Execute handler
+      result <- handler(req, res)
+
+      # Verify redirect response uses relative path
+      expect_equal(res$status, 301)
+      expect_equal(res$headers$Location, "../__docs__/")
+      expect_equal(res$body, "redirecting...")
+    }
+  )
+})
+
+test_that("swagger redirect handler works with apiPath", {
+  skip_if_not_installed("withr")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = "/api/v2"
+    ),
+    {
+      redirects <- swagger_redirects()
+      handler <- redirects[["/api/v2/__swagger__/index.html"]]$handler
+
+      # Create mock request and response
+      req <- make_req("GET", "/api/v2/__swagger__/index.html")
+      res <- PlumberResponse$new()
+
+      # Execute handler
+      result <- handler(req, res)
+
+      # Verify redirect response uses relative path
+      expect_equal(res$status, 301)
+      expect_equal(res$headers$Location, "../__docs__/index.html")
+      expect_equal(res$body, "redirecting...")
+    }
+  )
+})
+
+test_that("swagger redirects are mounted on plumber router", {
+  skip_if_not_installed("withr")
+  skip_if_not_installed("swagger")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = ""
+    ),
+    {
+      pr <- pr()
+      pr$handle("GET", "/test", function() "test")
+
+      docs_info <- list(
+        enabled = TRUE,
+        docs = "swagger",
+        args = list()
+      )
+
+      # Mount docs (which includes redirects)
+      mount_docs(
+        pr = pr,
+        host = "127.0.0.1",
+        port = 8000,
+        docs_info = docs_info,
+        callback = NULL,
+        quiet = TRUE
+      )
+
+      # Check that redirect endpoints are registered
+      endpoints <- pr$endpoints[["__no-preempt__"]]
+      endpoint_paths <- sapply(endpoints, function(e) e$path)
+
+      expect_true("/__swagger__/" %in% endpoint_paths)
+      expect_true("/__swagger__/index.html" %in% endpoint_paths)
+    }
+  )
+})
+
+test_that("swagger redirects work on mounted router with apiPath", {
+  skip_if_not_installed("withr")
+  skip_if_not_installed("swagger")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = "/myapp"
+    ),
+    {
+      pr <- pr()
+      pr$handle("GET", "/endpoint", function() "data")
+
+      docs_info <- list(
+        enabled = TRUE,
+        docs = "swagger",
+        args = list()
+      )
+
+      mount_docs(
+        pr = pr,
+        host = "127.0.0.1",
+        port = 8000,
+        docs_info = docs_info,
+        callback = NULL,
+        quiet = TRUE
+      )
+
+      # Find the redirect endpoint (should be prefixed with apiPath)
+      endpoints <- pr$endpoints[["__no-preempt__"]]
+      swagger_endpoint <- NULL
+      for (ep in endpoints) {
+        if (ep$path == "/myapp/__swagger__/") {
+          swagger_endpoint <- ep
+          break
+        }
+      }
+
+      expect_false(is.null(swagger_endpoint))
+
+      # Test the redirect by routing a request
+      req <- make_req("GET", "/myapp/__swagger__/", pr = pr)
+      res <- PlumberResponse$new()
+
+      result <- pr$route(req, res)
+
+      # Verify redirect uses relative path
+      expect_equal(res$status, 301)
+      expect_equal(res$headers$Location, "../__docs__/")
+    }
+  )
+})
+
+test_that("swagger redirects can be unmounted", {
+  skip_if_not_installed("withr")
+  skip_if_not_installed("swagger")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = ""
+    ),
+    {
+      pr <- pr()
+      pr$handle("GET", "/test", function() "test")
+
+      docs_info <- list(
+        enabled = TRUE,
+        docs = "swagger",
+        args = list()
+      )
+
+      # Mount docs
+      mount_docs(
+        pr = pr,
+        host = "127.0.0.1",
+        port = 8000,
+        docs_info = docs_info,
+        callback = NULL,
+        quiet = TRUE
+      )
+
+      # Verify redirects are mounted
+      endpoints_before <- pr$endpoints[["__no-preempt__"]]
+      paths_before <- sapply(endpoints_before, function(e) e$path)
+      expect_true("/__swagger__/" %in% paths_before)
+
+      # Unmount docs
+      unmount_docs(pr, docs_info)
+
+      # Verify redirects are unmounted
+      endpoints_after <- pr$endpoints[["__no-preempt__"]]
+      if (length(endpoints_after) > 0) {
+        paths_after <- sapply(endpoints_after, function(e) e$path)
+        expect_false("/__swagger__/" %in% paths_after)
+        expect_false("/__swagger__/index.html" %in% paths_after)
+      } else {
+        # No endpoints left is also valid
+        expect_length(endpoints_after, 0)
+      }
+    }
+  )
+})
+
+test_that("swagger redirect overwrite warning appears when route exists", {
+  skip_if_not_installed("withr")
+  skip_if_not_installed("swagger")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = ""
+    ),
+    {
+      pr <- pr()
+      # Pre-register a route at the same path as the redirect
+      pr$handle("GET", "/__swagger__/", function() "existing")
+
+      docs_info <- list(
+        enabled = TRUE,
+        docs = "swagger",
+        args = list()
+      )
+
+      # Mounting docs should show overwrite warning
+      expect_message(
+        mount_docs(
+          pr = pr,
+          host = "127.0.0.1",
+          port = 8000,
+          docs_info = docs_info,
+          callback = NULL,
+          quiet = TRUE
+        ),
+        "Overwriting existing GET endpoint: /__swagger__/"
+      )
+    }
+  )
+})
+
+test_that("swagger redirects work with nested apiPath", {
+  skip_if_not_installed("withr")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = "/api/v1/myapp"
+    ),
+    {
+      redirects <- swagger_redirects()
+
+      # Verify redirect keys include full nested path
+      expect_true("/api/v1/myapp/__swagger__/" %in% names(redirects))
+      expect_true("/api/v1/myapp/__swagger__/index.html" %in% names(redirects))
+
+      # Targets use relative paths
+      expect_equal(
+        redirects[["/api/v1/myapp/__swagger__/"]]$route,
+        "../__docs__/"
+      )
+      expect_equal(
+        redirects[["/api/v1/myapp/__swagger__/index.html"]]$route,
+        "../__docs__/index.html"
+      )
+    }
+  )
+})
+
+test_that("swagger redirects respect environment variable for apiPath", {
+  skip_if_not_installed("withr")
+
+  withr::with_envvar(
+    list(PLUMBER_APIPATH = "/env/api"),
+    {
+      withr::with_options(
+        list(
+          plumber.legacyRedirects = TRUE,
+          plumber.apiPath = NULL  # Clear option to use env var
+        ),
+        {
+          redirects <- swagger_redirects()
+
+          # Should use environment variable in redirect keys
+          expect_true("/env/api/__swagger__/" %in% names(redirects))
+          # Targets use relative paths
+          expect_equal(
+            redirects[["/env/api/__swagger__/"]]$route,
+            "../__docs__/"
+          )
+        }
+      )
+    }
+  )
+})
+
+test_that("swagger redirects handle empty apiPath correctly", {
+  skip_if_not_installed("withr")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = ""
+    ),
+    {
+      redirects <- swagger_redirects()
+
+      # Empty string should behave same as NULL, uses relative paths
+      expect_equal(redirects[["/__swagger__/"]]$route, "../__docs__/")
+      expect_equal(
+        redirects[["/__swagger__/index.html"]]$route,
+        "../__docs__/index.html"
+      )
+    }
+  )
+})
+
+test_that("multiple swagger redirects on same router work independently", {
+  skip_if_not_installed("withr")
+  skip_if_not_installed("swagger")
+
+  withr::with_options(
+    list(
+      plumber.legacyRedirects = TRUE,
+      plumber.apiPath = "/v1"
+    ),
+    {
+      pr <- pr()
+      pr$handle("GET", "/test", function() "test")
+
+      docs_info <- list(
+        enabled = TRUE,
+        docs = "swagger",
+        args = list()
+      )
+
+      mount_docs(pr, "127.0.0.1", 8000, docs_info, NULL, TRUE)
+
+      # Test both redirect endpoints (with apiPath prefix)
+      req1 <- make_req("GET", "/v1/__swagger__/", pr = pr)
+      res1 <- PlumberResponse$new()
+      pr$route(req1, res1)
+
+      req2 <- make_req("GET", "/v1/__swagger__/index.html", pr = pr)
+      res2 <- PlumberResponse$new()
+      pr$route(req2, res2)
+
+      # Both should redirect correctly using relative paths
+      expect_equal(res1$status, 301)
+      expect_equal(res1$headers$Location, "../__docs__/")
+
+      expect_equal(res2$status, 301)
+      expect_equal(res2$headers$Location, "../__docs__/index.html")
+    }
+  )
+})

--- a/tests/testthat/test-ui-apipath.R
+++ b/tests/testthat/test-ui-apipath.R
@@ -176,7 +176,7 @@ test_that("swagger_redirects respects plumber.apiPath option", {
       # Test with default (empty) apiPath
       redirects <- swagger_redirects()
       expect_true("/__swagger__/" %in% names(redirects))
-      expect_equal(redirects[["/__swagger__/"]]$route, "/__docs__/")
+      expect_equal(redirects[["/__swagger__/"]]$route, "../__docs__/")
     }
   )
 
@@ -188,9 +188,11 @@ test_that("swagger_redirects respects plumber.apiPath option", {
     ),
     {
       redirects <- swagger_redirects()
-      expect_true("/__swagger__/" %in% names(redirects))
-      expect_equal(redirects[["/__swagger__/"]]$route, "/api/v1/__docs__/")
-      expect_equal(redirects[["/__swagger__/index.html"]]$route, "/api/v1/__docs__/index.html")
+      # With apiPath, redirect keys include the prefix
+      expect_true("/api/v1/__swagger__/" %in% names(redirects))
+      # Targets use relative paths
+      expect_equal(redirects[["/api/v1/__swagger__/"]]$route, "../__docs__/")
+      expect_equal(redirects[["/api/v1/__swagger__/index.html"]]$route, "../__docs__/index.html")
     }
   )
 })


### PR DESCRIPTION
## Summary

This PR adds comprehensive unit tests for the swagger redirect functionality that was fixed in the recent commit addressing issue #1016.

## Changes

### New Test File
- **[tests/testthat/test-swagger-redirects.R](tests/testthat/test-swagger-redirects.R)** (417 lines, 39 tests)
  - Tests redirect structure with default and custom apiPath
  - Tests redirect handlers return correct 301 status codes
  - Tests integration with plumber routers
  - Tests mounting/unmounting behavior
  - Tests edge cases (nested paths, env variables, empty paths)

### Updated Test Files
- **[tests/testthat/test-ui-apipath.R](tests/testthat/test-ui-apipath.R)**
  - Updated existing `swagger_redirects` test to match new relative path behavior

## Test Coverage

The new tests verify:

1. **Basic Redirect Functionality**
   - Correct redirect structure generation
   - Custom apiPath handling
   - Disabled redirects when `plumber.legacyRedirects = FALSE`

2. **Redirect Handlers**
   - 301 permanent redirect status codes
   - Relative path redirects (`../__docs__/`) instead of absolute paths
   - Proper handler execution with mock requests/responses

3. **Router Integration**
   - Redirects properly mounted on plumber routers
   - Correct behavior with various apiPath configurations (empty, `/api/v1`, nested)
   - Full request routing through redirect endpoints

4. **Unmounting & Cleanup**
   - Proper cleanup when docs are unmounted
   - Overwrite warnings when routes conflict

5. **Edge Cases**
   - Nested apiPath values (`/api/v1/myapp`)
   - Environment variable support (`PLUMBER_APIPATH`)
   - Empty apiPath handling
   - Multiple independent redirects on same router

## Implementation Details

The redirect implementation uses:
- **Redirect keys** that include the apiPath prefix (e.g., `/api/v2/__swagger__/`)
- **Relative path targets** (`../__docs__/`) to ensure redirects work correctly regardless of apiPath configuration
- This approach works seamlessly with RStudio Connect and other hosting environments

## Test Results

All 39 tests pass successfully:

```
✔ | F W S  OK | Context
✔ |        39 | Swagger redirects

══ Results ═════════════════════════════════════════════════
Duration: 0.8 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 39 ]
```

## Integration Verification

Verified the redirects work correctly on a live plumber app:

```r
# With default apiPath
Endpoints: /__swagger__/, /__swagger__/index.html
Redirect: 301 → ../__docs__/

# With custom apiPath (/api/v2)
Endpoints: /api/v2/__swagger__/, /api/v2/__swagger__/index.html
Redirect: 301 → ../__docs__/
```

## Related Issues

* Fixes #1016
* Related #977 / #836

## Checklist

- [x] Added comprehensive unit tests
- [x] All tests pass locally
- [x] Updated existing tests to match new behavior
- [x] Verified integration with working plumber apps
- [x] Tests cover edge cases and various configurations