### PR TITLE
Support _server.yml applications

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -96,6 +96,7 @@ Collate:
     'pr.R'
     'pr_set.R'
     'serializer.R'
+    'server-yml.R'
     'session-cookie.R'
     'ui.R'
     'utf8.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # plumber (development version)
 
+* Plumber can now serve `_server.yml` applications through its internal
+  server-engine entry point. Applications without a root route redirect to
+  their visual documentation (#1017).
+
 # plumber 1.3.3
 
 ## Bug fixes and minor improvements

--- a/R/server-yml.R
+++ b/R/server-yml.R
@@ -1,0 +1,38 @@
+# `_server.yml` engine entry point. This function is intentionally not exported;
+# deployment tools retrieve it from the package namespace.
+launch_server <- function(settings, host = NULL, port = NULL, ...) {
+  if (!is.character(settings) || length(settings) != 1L || is.na(settings)) {
+    stop("`settings` must be the path to a `_server.yml` file.")
+  }
+
+  settings <- normalizePath(settings, winslash = "/", mustWork = TRUE)
+  router <- plumb(dir = dirname(settings))
+  router <- add_server_docs_redirect(router)
+
+  args <- list(pr = router, ...)
+  if (!is.null(host)) {
+    args$host <- host
+  }
+  if (!is.null(port)) {
+    args$port <- port
+  }
+
+  do.call(pr_run, args)
+}
+
+add_server_docs_redirect <- function(router) {
+  api_path <- get_option_or_env("plumber.apiPath", "")
+  api_path <- sub("/+$", "", api_path)
+  root_path <- paste0(api_path, "/")
+
+  if (router_has_route(router, root_path, "GET")) {
+    return(router)
+  }
+
+  pr_get(router, root_path, function(req, res) {
+    res$status <- 301
+    res$setHeader("Location", "./__docs__/")
+    res$body <- "redirecting..."
+    res
+  })
+}

--- a/tests/testthat/test-server-yml.R
+++ b/tests/testthat/test-server-yml.R
@@ -1,0 +1,111 @@
+make_server_yml_app <- function(plumber_lines, filename = "plumber.R") {
+  app_dir <- withr::local_tempdir(.local_envir = parent.frame())
+  writeLines("engine: plumber", file.path(app_dir, "_server.yml"))
+  writeLines(plumber_lines, file.path(app_dir, filename))
+  app_dir
+}
+
+test_that("launch_server starts the API beside _server.yml", {
+  app_dir <- make_server_yml_app(c(
+    "#* @get /ping",
+    "function() 'pong'"
+  ))
+
+  local_mocked_bindings(
+    pr_run = function(pr, host = "127.0.0.1", port = NULL, ...) {
+      list(pr = pr, host = host, port = port, dots = list(...))
+    }
+  )
+
+  result <- launch_server(
+    file.path(app_dir, "_server.yml"),
+    host = "0.0.0.0",
+    port = 8080,
+    quiet = TRUE
+  )
+
+  expect_s3_class(result$pr, "Plumber")
+  expect_true(router_has_route(result$pr, "/ping", "GET"))
+  expect_true(router_has_route(result$pr, "/", "GET"))
+  expect_identical(result$host, "0.0.0.0")
+  expect_identical(result$port, 8080)
+  expect_true(result$dots$quiet)
+
+  root_endpoint <- Filter(
+    function(endpoint) identical(endpoint$path, "/"),
+    result$pr$endpoints[["__no-preempt__"]]
+  )[[1]]
+  response <- root_endpoint$getFunc()(
+    make_req("GET", "/"),
+    PlumberResponse$new()
+  )
+  expect_identical(response$status, 301)
+  expect_identical(response$headers$Location, "./__docs__/")
+})
+
+test_that("launch_server leaves host and port defaults to pr_run", {
+  app_dir <- make_server_yml_app(c(
+    "#* @get /ping",
+    "function() 'pong'"
+  ))
+
+  local_mocked_bindings(
+    pr_run = function(pr, host = "default-host", port = "default-port", ...) {
+      list(host = host, port = port)
+    }
+  )
+
+  result <- launch_server(file.path(app_dir, "_server.yml"))
+
+  expect_identical(result$host, "default-host")
+  expect_identical(result$port, "default-port")
+})
+
+test_that("launch_server supports entrypoint.R applications", {
+  app_dir <- make_server_yml_app(c(
+    "plumber::pr_get(",
+    "  plumber::pr(), '/ping', function() 'pong'",
+    ")"
+  ), filename = "entrypoint.R")
+
+  local_mocked_bindings(pr_run = function(pr, ...) pr)
+  router <- launch_server(file.path(app_dir, "_server.yml"))
+
+  expect_true(router_has_route(router, "/ping", "GET"))
+})
+
+test_that("launch_server does not replace an application root route", {
+  app_dir <- make_server_yml_app(c(
+    "#* @get /",
+    "function() 'home'"
+  ))
+
+  local_mocked_bindings(pr_run = function(pr, ...) pr)
+  router <- launch_server(file.path(app_dir, "_server.yml"))
+  root_endpoints <- Filter(
+    function(endpoint) identical(endpoint$path, "/"),
+    router$endpoints[["__no-preempt__"]]
+  )
+
+  expect_length(root_endpoints, 1L)
+})
+
+test_that("server docs redirect respects apiPath", {
+  app_dir <- make_server_yml_app(c(
+    "#* @get /ping",
+    "function() 'pong'"
+  ))
+
+  withr::local_options(plumber.apiPath = "/service")
+  local_mocked_bindings(pr_run = function(pr, ...) pr)
+  router <- launch_server(file.path(app_dir, "_server.yml"))
+
+  expect_true(router_has_route(router, "/service/", "GET"))
+  expect_false(router_has_route(router, "/", "GET"))
+})
+
+test_that("launch_server requires one settings path", {
+  expect_error(launch_server(NULL), "must be the path")
+  expect_error(launch_server(c("a", "b")), "must be the path")
+  expect_error(launch_server(NA_character_), "must be the path")
+})

--- a/vignettes/hosting.Rmd
+++ b/vignettes/hosting.Rmd
@@ -23,6 +23,19 @@ Once you have developed your Plumber API, the next step is to find a way to host
 
 For these reasons and more, you should consider setting up a separate server on which you can host your Plumber APIs. There are a variety of options that you can consider.
 
+## `_server.yml`
+
+Hosting platforms that implement the [`_server.yml` standard](https://plumber2.posit.co/articles/server_yml.html) can launch a Plumber API from this file at the application root:
+
+```yaml
+engine: plumber
+```
+
+Place `plumber.R` in the same directory. Alternatively, use an `entrypoint.R`
+file that returns a Plumber router. The hosting platform supplies the network
+host and port when it starts the API. If the application has no root `GET`
+route, Plumber redirects the application root to its visual documentation.
+
 ## Posit Connect {#posit-connect}
 
 [Posit Connect](https://posit.co/products/enterprise/connect/) is an enterprise publishing platform from Posit. It supports push-button publishing from the RStudio IDE of a variety of R content types including Plumber APIs. Unlike all the other options listed here, Posit Connect automatically manages the dependent packages and files your API has and recreates an environment closely mimicking your local development environment on the server.


### PR DESCRIPTION
## Summary

Add the internal server-engine entry point expected by `_server.yml` hosting tools.

## Thanks to maintainers

Thanks for confirming that the standard fits plumber and for pointing out the root documentation redirect required by existing deployments.

## Issue or motivation

Closes #1017. A hosting tool can identify `engine: plumber`, but plumber currently has no namespace-level `launch_server()` function for it to call.

## Root cause

`plumb()` already discovers `plumber.R` and `entrypoint.R`, while `pr_run()` already handles host and port selection. The missing layer was the standard launcher that connects those functions and adds the root redirect that Connect supplies separately.

## Change

- Resolve the application directory relative to `_server.yml`, build its router, and pass non-`NULL` host and port values to `pr_run()`.
- Redirect the application root to `./__docs__/` only when the router has no root `GET` route; respect `plumber.apiPath`.
- Document the minimal `_server.yml` setup and add a NEWS entry.

## Tests

- `devtools::test(filter = "server-yml|plumber-run|ui-apipath|swagger-redirects", stop_on_failure = TRUE)`: 98 passed.
- `devtools::check(document = FALSE, error_on = "warning")`: 0 errors and 0 warnings. The two NOTEs are the existing `spelling.Rout.save` prompt-format difference under R 4.6 and `node-compile-cache` left in the temporary check directory.
- `devtools::document()` and a direct render of `vignettes/hosting.Rmd` completed successfully.

## Scope

This does not export a new user-facing API, parse additional `_server.yml` fields, add dependencies, or replace an application's existing root route.
